### PR TITLE
feat(llms): emit llms.txt, llms-full.txt, and per-page markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "fs-extra": "^11.3.5",
     "gray-matter": "^4.0.3",
     "next": "^16.2.6",
-    "prettier": "^3.8.3",
     "prompts": "^2.4.2",
     "react": "^19.2.6",
     "react-dom": "^19.2.6"
@@ -49,6 +48,7 @@
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^25.6.2",
     "@types/prompts": "^2.4.9",
+    "prettier": "^3.8.3",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"
   },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "fs-extra": "^11.3.5",
     "gray-matter": "^4.0.3",
     "next": "^16.2.6",
+    "prettier": "^3.8.3",
     "prompts": "^2.4.2",
     "react": "^19.2.6",
     "react-dom": "^19.2.6"
@@ -48,7 +49,6 @@
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^25.6.2",
     "@types/prompts": "^2.4.9",
-    "prettier": "^3.8.3",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       next:
         specifier: ^16.2.6
         version: 16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      prettier:
+        specifier: ^3.8.3
+        version: 3.8.3
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
@@ -45,9 +48,6 @@ importers:
       '@types/prompts':
         specifier: ^2.4.9
         version: 2.4.9
-      prettier:
-        specifier: ^3.8.3
-        version: 3.8.3
       typescript:
         specifier: ^6.0.3
         version: 6.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       next:
         specifier: ^16.2.6
         version: 16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      prettier:
-        specifier: ^3.8.3
-        version: 3.8.3
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
@@ -48,6 +45,9 @@ importers:
       '@types/prompts':
         specifier: ^2.4.9
         version: 2.4.9
+      prettier:
+        specifier: ^3.8.3
+        version: 3.8.3
       typescript:
         specifier: ^6.0.3
         version: 6.0.3

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from "url";
 
 import matter from "gray-matter";
 import chalk from "chalk";
+import prettier from "prettier";
 
 import { appStructure, startingDocsStructure } from "./lib/structures.js";
 import { layoutTemplate } from "./lib/layout.js";
@@ -1460,7 +1461,26 @@ export default function Page() {
   private async writeLlmsManifest(pageFiles: Set<string>): Promise<void> {
     const manifestPath = this.llmsManifestPath();
     const payload = { pageFiles: Array.from(pageFiles).sort() };
-    await fs.writeFile(manifestPath, JSON.stringify(payload, null, 2), "utf8");
+    const json = JSON.stringify(payload, null, 2) + "\n";
+    await fs.writeFile(manifestPath, json, "utf8");
+  }
+
+  private async formatMarkdown(
+    content: string,
+    targetPath: string,
+  ): Promise<string> {
+    try {
+      const config =
+        (await prettier.resolveConfig(targetPath)) ??
+        (await prettier.resolveConfig(this.outputDir)) ??
+        {};
+      return await prettier.format(content, {
+        ...config,
+        parser: "markdown",
+      });
+    } catch {
+      return content.endsWith("\n") ? content : content + "\n";
+    }
   }
 
   async updateLlmsFiles() {
@@ -1488,10 +1508,16 @@ export default function Page() {
       sectionsConfig: this.sectionsConfig,
     });
 
-    await fs.writeFile(path.join(publicDir, "llms.txt"), indexContent, "utf8");
+    const indexPath = path.join(publicDir, "llms.txt");
+    const fullPath = path.join(publicDir, "llms-full.txt");
     await fs.writeFile(
-      path.join(publicDir, "llms-full.txt"),
-      fullContent,
+      indexPath,
+      await this.formatMarkdown(indexContent, indexPath),
+      "utf8",
+    );
+    await fs.writeFile(
+      fullPath,
+      await this.formatMarkdown(fullContent, fullPath),
       "utf8",
     );
 
@@ -1501,7 +1527,12 @@ export default function Page() {
       const relPath = `${page.slug}.md`;
       const targetPath = path.join(publicDir, relPath);
       await fs.ensureDir(path.dirname(targetPath));
-      await fs.writeFile(targetPath, llmsPageTemplate(page, baseUrl), "utf8");
+      const pageContent = llmsPageTemplate(page, baseUrl);
+      await fs.writeFile(
+        targetPath,
+        await this.formatMarkdown(pageContent, targetPath),
+        "utf8",
+      );
       nextRelativePaths.add(relPath);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import {
   generateJsonLdScript,
 } from "./lib/metadata.js";
 import { nextConfigTemplate } from "./templates/next.config.js";
+import { pnpmWorkspaceTemplate } from "./templates/pnpmWorkspace.js";
 import { proxyTemplate } from "./templates/proxy.js";
 import { robotsTemplate } from "./templates/app/robots.js";
 import { sitemapTemplate, type SitemapEntry } from "./templates/app/sitemap.js";
@@ -132,6 +133,7 @@ class MDXToNextJSGenerator {
     const structure: Record<string, string | Promise<string>> = {
       ...appStructure,
       "next.config.ts": nextConfigTemplate(this.analyticsConfig),
+      "pnpm-workspace.yaml": pnpmWorkspaceTemplate,
       "proxy.ts": proxyTemplate(this.analyticsConfig),
       "analytics.json": `{}\n`,
       "config.json": `{}\n`,
@@ -1608,7 +1610,7 @@ program
 
     const install = spawn(packageManager, ["install"], {
       cwd: config.outputDir,
-      stdio: "pipe",
+      stdio: "inherit",
     });
 
     await new Promise((resolve, reject) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,12 @@ import { nextConfigTemplate } from "./templates/next.config.js";
 import { proxyTemplate } from "./templates/proxy.js";
 import { robotsTemplate } from "./templates/app/robots.js";
 import { sitemapTemplate, type SitemapEntry } from "./templates/app/sitemap.js";
+import { llmsIndexTemplate } from "./templates/llms/llmsIndex.js";
+import {
+  llmsFullTemplate,
+  type PageWithBody,
+} from "./templates/llms/llmsFull.js";
+import { llmsPageTemplate } from "./templates/llms/llmsPage.js";
 import type {
   MDXFile,
   PageMeta,
@@ -71,6 +77,8 @@ class MDXToNextJSGenerator {
   private sectionsConfig: SectionConfig[] | null = null;
   /** Guards against recursive reprocessing when maybeUpdateSections() triggers processAllMDXFiles() */
   private isReprocessing = false;
+  /** Tracks per-page .md files written under public/ so we can clean up stale ones on rename/delete */
+  private generatedLlmsPagePaths = new Set<string>();
 
   constructor(watchDir: string, outputDir: string) {
     this.watchDir = path.resolve(watchDir);
@@ -142,6 +150,7 @@ class MDXToNextJSGenerator {
     }
 
     await this.updateSitemap();
+    await this.updateLlmsFiles();
   }
 
   async createStartingDocs() {
@@ -446,6 +455,7 @@ class MDXToNextJSGenerator {
         if (fileName === "config.json") {
           await this.updateSitemap();
           await this.updateRobots();
+          await this.updateLlmsFiles();
         }
       } catch (error) {
         console.error(chalk.red(`❌ Error copying ${fileName}:`), error);
@@ -472,6 +482,7 @@ class MDXToNextJSGenerator {
         if (fileName === "config.json") {
           await this.updateSitemap();
           await this.updateRobots();
+          await this.updateLlmsFiles();
         }
       } catch (error) {
         console.error(chalk.red(`❌ Error removing ${fileName}:`), error);
@@ -924,6 +935,7 @@ class MDXToNextJSGenerator {
       await this.updatePagesIndex();
       await this.updateRootLayout();
       await this.updateSitemap();
+      await this.updateLlmsFiles();
       await this.generateSectionIndexPages();
 
       console.log(chalk.green(`✅ Generated page for: ${filePath}`));
@@ -954,6 +966,7 @@ class MDXToNextJSGenerator {
       await this.updatePagesIndex();
       await this.updateRootLayout();
       await this.updateSitemap();
+      await this.updateLlmsFiles();
 
       console.log(chalk.green(`✅ Removed page for: ${filePath}`));
 
@@ -1360,6 +1373,161 @@ export default function Page() {
         siteUrl
           ? `🤖 Regenerated robots.ts with sitemap link`
           : `🤖 Regenerated robots.ts (no sitemap link)`,
+      ),
+    );
+  }
+
+  private async loadSiteMetadata(): Promise<{
+    url: string | null;
+    name: string;
+    description: string;
+  }> {
+    const configPath = path.join(this.rootDir, "config.json");
+    let url: string | null = null;
+    let name = "Documentation";
+    let description = "";
+
+    try {
+      if (await fs.pathExists(configPath)) {
+        const content = await fs.readFile(configPath, "utf8");
+        const parsed = JSON.parse(content) as {
+          url?: unknown;
+          name?: unknown;
+          title?: unknown;
+          description?: unknown;
+        };
+        if (typeof parsed.url === "string" && parsed.url.trim() !== "") {
+          url = parsed.url.trim().replace(/\/$/, "");
+        }
+        if (typeof parsed.name === "string" && parsed.name.trim() !== "") {
+          name = parsed.name.trim();
+        } else if (
+          typeof parsed.title === "string" &&
+          parsed.title.trim() !== ""
+        ) {
+          name = parsed.title.trim();
+        }
+        if (
+          typeof parsed.description === "string" &&
+          parsed.description.trim() !== ""
+        ) {
+          description = parsed.description.trim();
+        }
+      }
+    } catch (error) {
+      console.warn(
+        chalk.yellow("⚠️ Error reading config.json for llms metadata"),
+        error,
+      );
+    }
+
+    return { url, name, description };
+  }
+
+  private async readPageWithBody(page: PageMeta): Promise<PageWithBody> {
+    const fullPath = path.join(this.watchDir, page.path);
+    const raw = await fs.readFile(fullPath, "utf8");
+    const { content: body } = matter(raw);
+    return { ...page, body };
+  }
+
+  private llmsManifestPath(): string {
+    return path.join(this.outputDir, ".doccupine-llms-manifest.json");
+  }
+
+  private async readLlmsManifest(): Promise<Set<string>> {
+    const manifestPath = this.llmsManifestPath();
+    try {
+      if (await fs.pathExists(manifestPath)) {
+        const raw = await fs.readFile(manifestPath, "utf8");
+        const parsed = JSON.parse(raw) as { pageFiles?: unknown };
+        if (Array.isArray(parsed.pageFiles)) {
+          return new Set(
+            parsed.pageFiles.filter(
+              (entry): entry is string => typeof entry === "string",
+            ),
+          );
+        }
+      }
+    } catch {
+      // ignore corrupted manifest
+    }
+    return new Set();
+  }
+
+  private async writeLlmsManifest(pageFiles: Set<string>): Promise<void> {
+    const manifestPath = this.llmsManifestPath();
+    const payload = { pageFiles: Array.from(pageFiles).sort() };
+    await fs.writeFile(manifestPath, JSON.stringify(payload, null, 2), "utf8");
+  }
+
+  async updateLlmsFiles() {
+    const publicDir = path.join(this.outputDir, "public");
+    await fs.ensureDir(publicDir);
+
+    const { url: baseUrl, name, description } = await this.loadSiteMetadata();
+    const pages = await this.buildAllPagesMeta();
+    const pagesWithBodies = await Promise.all(
+      pages.map((page) => this.readPageWithBody(page)),
+    );
+
+    const indexContent = llmsIndexTemplate({
+      siteName: name,
+      siteDescription: description,
+      baseUrl,
+      pages,
+      sectionsConfig: this.sectionsConfig,
+    });
+    const fullContent = llmsFullTemplate({
+      siteName: name,
+      siteDescription: description,
+      baseUrl,
+      pages: pagesWithBodies,
+      sectionsConfig: this.sectionsConfig,
+    });
+
+    await fs.writeFile(path.join(publicDir, "llms.txt"), indexContent, "utf8");
+    await fs.writeFile(
+      path.join(publicDir, "llms-full.txt"),
+      fullContent,
+      "utf8",
+    );
+
+    const nextRelativePaths = new Set<string>();
+    for (const page of pagesWithBodies) {
+      if (page.slug === "") continue;
+      const relPath = `${page.slug}.md`;
+      const targetPath = path.join(publicDir, relPath);
+      await fs.ensureDir(path.dirname(targetPath));
+      await fs.writeFile(targetPath, llmsPageTemplate(page, baseUrl), "utf8");
+      nextRelativePaths.add(relPath);
+    }
+
+    const previousRelativePaths = new Set<string>([
+      ...this.generatedLlmsPagePaths,
+      ...(await this.readLlmsManifest()),
+    ]);
+
+    for (const stale of previousRelativePaths) {
+      if (!nextRelativePaths.has(stale)) {
+        try {
+          const stalePath = path.join(publicDir, stale);
+          if (await fs.pathExists(stalePath)) {
+            await fs.remove(stalePath);
+          }
+        } catch {
+          // ignore
+        }
+      }
+    }
+    this.generatedLlmsPagePaths = nextRelativePaths;
+    await this.writeLlmsManifest(nextRelativePaths);
+
+    console.log(
+      chalk.green(
+        `🤖 Generated llms.txt and llms-full.txt with ${pages.length} page(s)${
+          baseUrl ? ` using ${baseUrl}` : " (relative URLs)"
+        }`,
       ),
     );
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ import { fileURLToPath } from "url";
 
 import matter from "gray-matter";
 import chalk from "chalk";
-import prettier from "prettier";
 
 import { appStructure, startingDocsStructure } from "./lib/structures.js";
 import { layoutTemplate } from "./lib/layout.js";
@@ -1465,24 +1464,6 @@ export default function Page() {
     await fs.writeFile(manifestPath, json, "utf8");
   }
 
-  private async formatMarkdown(
-    content: string,
-    targetPath: string,
-  ): Promise<string> {
-    try {
-      const config =
-        (await prettier.resolveConfig(targetPath)) ??
-        (await prettier.resolveConfig(this.outputDir)) ??
-        {};
-      return await prettier.format(content, {
-        ...config,
-        parser: "markdown",
-      });
-    } catch {
-      return content.endsWith("\n") ? content : content + "\n";
-    }
-  }
-
   async updateLlmsFiles() {
     const publicDir = path.join(this.outputDir, "public");
     await fs.ensureDir(publicDir);
@@ -1508,33 +1489,24 @@ export default function Page() {
       sectionsConfig: this.sectionsConfig,
     });
 
-    const indexPath = path.join(publicDir, "llms.txt");
-    const fullPath = path.join(publicDir, "llms-full.txt");
+    await fs.writeFile(path.join(publicDir, "llms.txt"), indexContent, "utf8");
     await fs.writeFile(
-      indexPath,
-      await this.formatMarkdown(indexContent, indexPath),
-      "utf8",
-    );
-    await fs.writeFile(
-      fullPath,
-      await this.formatMarkdown(fullContent, fullPath),
+      path.join(publicDir, "llms-full.txt"),
+      fullContent,
       "utf8",
     );
 
     const nextRelativePaths = new Set<string>();
-    for (const page of pagesWithBodies) {
-      if (page.slug === "") continue;
-      const relPath = `${page.slug}.md`;
-      const targetPath = path.join(publicDir, relPath);
-      await fs.ensureDir(path.dirname(targetPath));
-      const pageContent = llmsPageTemplate(page, baseUrl);
-      await fs.writeFile(
-        targetPath,
-        await this.formatMarkdown(pageContent, targetPath),
-        "utf8",
-      );
-      nextRelativePaths.add(relPath);
-    }
+    await Promise.all(
+      pagesWithBodies.map(async (page) => {
+        if (page.slug === "") return;
+        const relPath = `${page.slug}.md`;
+        const targetPath = path.join(publicDir, relPath);
+        await fs.ensureDir(path.dirname(targetPath));
+        await fs.writeFile(targetPath, llmsPageTemplate(page, baseUrl), "utf8");
+        nextRelativePaths.add(relPath);
+      }),
+    );
 
     const previousRelativePaths = new Set<string>([
       ...this.generatedLlmsPagePaths,

--- a/src/templates/llms/llmsFull.ts
+++ b/src/templates/llms/llmsFull.ts
@@ -1,0 +1,81 @@
+import type { PageMeta, SectionConfig } from "../../lib/types.js";
+
+export interface PageWithBody extends PageMeta {
+  body: string;
+}
+
+export interface LlmsFullArgs {
+  siteName: string;
+  siteDescription?: string;
+  baseUrl: string | null;
+  pages: PageWithBody[];
+  sectionsConfig: SectionConfig[] | null;
+}
+
+function pageUrl(slug: string, baseUrl: string | null): string {
+  if (baseUrl) {
+    return slug === "" ? `${baseUrl}/` : `${baseUrl}/${slug}`;
+  }
+  return slug === "" ? "/" : `/${slug}`;
+}
+
+function orderedPages(
+  pages: PageWithBody[],
+  sectionsConfig: SectionConfig[] | null,
+): PageWithBody[] {
+  const sectionOrderIndex = new Map<string, number>();
+  sectionOrderIndex.set("", 0);
+  if (sectionsConfig) {
+    sectionsConfig.forEach((section, idx) => {
+      sectionOrderIndex.set(section.slug, idx + 1);
+    });
+  }
+
+  return [...pages].sort((a, b) => {
+    const sa = sectionOrderIndex.get(a.section) ?? 999;
+    const sb = sectionOrderIndex.get(b.section) ?? 999;
+    if (sa !== sb) return sa - sb;
+    if (a.categoryOrder !== b.categoryOrder)
+      return a.categoryOrder - b.categoryOrder;
+    if (a.category !== b.category) return a.category.localeCompare(b.category);
+    if (a.order !== b.order) return a.order - b.order;
+    return a.title.localeCompare(b.title);
+  });
+}
+
+export function llmsFullTemplate(args: LlmsFullArgs): string {
+  const { siteName, siteDescription, baseUrl, pages, sectionsConfig } = args;
+  const lines: string[] = [];
+
+  lines.push(`# ${siteName}`);
+  lines.push("");
+  lines.push(`> Full documentation for ${siteName}.`);
+  if (siteDescription && siteDescription.trim() !== "") {
+    lines.push("");
+    lines.push(siteDescription.trim());
+  }
+  lines.push("");
+
+  if (pages.length === 0) {
+    return lines.join("\n") + "\n";
+  }
+
+  const sorted = orderedPages(pages, sectionsConfig);
+
+  for (const page of sorted) {
+    lines.push("---");
+    lines.push("");
+    lines.push(`# ${page.title}`);
+    lines.push("");
+    if (page.description && page.description.trim() !== "") {
+      lines.push(`> ${page.description.trim()}`);
+      lines.push("");
+    }
+    lines.push(`Source: ${pageUrl(page.slug, baseUrl)}`);
+    lines.push("");
+    lines.push(page.body.trim());
+    lines.push("");
+  }
+
+  return lines.join("\n").replace(/\n+$/, "\n");
+}

--- a/src/templates/llms/llmsIndex.ts
+++ b/src/templates/llms/llmsIndex.ts
@@ -1,0 +1,153 @@
+import type { PageMeta, SectionConfig } from "../../lib/types.js";
+
+export interface LlmsIndexArgs {
+  siteName: string;
+  siteDescription?: string;
+  baseUrl: string | null;
+  pages: PageMeta[];
+  sectionsConfig: SectionConfig[] | null;
+}
+
+interface CategoryGroup {
+  category: string;
+  minCategoryOrder: number;
+  pages: PageMeta[];
+}
+
+interface SectionGroup {
+  sectionSlug: string;
+  sectionLabel: string;
+  sectionOrder: number;
+  categories: CategoryGroup[];
+}
+
+function pageUrl(slug: string, baseUrl: string | null): string {
+  if (baseUrl) {
+    return slug === "" ? `${baseUrl}/` : `${baseUrl}/${slug}`;
+  }
+  return slug === "" ? "/" : `/${slug}`;
+}
+
+function comparePages(a: PageMeta, b: PageMeta): number {
+  if (a.order !== b.order) return a.order - b.order;
+  return a.title.localeCompare(b.title);
+}
+
+function buildSectionGroups(
+  pages: PageMeta[],
+  sectionsConfig: SectionConfig[] | null,
+): SectionGroup[] {
+  const sectionOrderIndex = new Map<string, number>();
+  sectionOrderIndex.set("", 0);
+  if (sectionsConfig) {
+    sectionsConfig.forEach((section, idx) => {
+      sectionOrderIndex.set(section.slug, idx + 1);
+    });
+  }
+
+  const sectionLabelByslug = new Map<string, string>();
+  if (sectionsConfig) {
+    for (const section of sectionsConfig) {
+      sectionLabelByslug.set(section.slug, section.label);
+    }
+  }
+
+  const bySection = new Map<string, PageMeta[]>();
+  for (const page of pages) {
+    const key = page.section || "";
+    const list = bySection.get(key) ?? [];
+    list.push(page);
+    bySection.set(key, list);
+  }
+
+  const groups: SectionGroup[] = [];
+  for (const [sectionSlug, sectionPages] of bySection) {
+    const byCategory = new Map<string, PageMeta[]>();
+    for (const page of sectionPages) {
+      const key = page.category || "";
+      const list = byCategory.get(key) ?? [];
+      list.push(page);
+      byCategory.set(key, list);
+    }
+
+    const categories: CategoryGroup[] = [];
+    for (const [category, catPages] of byCategory) {
+      catPages.sort(comparePages);
+      const minCategoryOrder = catPages.reduce(
+        (min, p) => Math.min(min, p.categoryOrder),
+        Number.POSITIVE_INFINITY,
+      );
+      categories.push({
+        category,
+        minCategoryOrder: Number.isFinite(minCategoryOrder)
+          ? minCategoryOrder
+          : 0,
+        pages: catPages,
+      });
+    }
+
+    categories.sort((a, b) => {
+      if (a.minCategoryOrder !== b.minCategoryOrder) {
+        return a.minCategoryOrder - b.minCategoryOrder;
+      }
+      return a.category.localeCompare(b.category);
+    });
+
+    groups.push({
+      sectionSlug,
+      sectionLabel:
+        sectionLabelByslug.get(sectionSlug) ??
+        (sectionSlug === "" ? "Documentation" : sectionSlug),
+      sectionOrder: sectionOrderIndex.get(sectionSlug) ?? 999,
+      categories,
+    });
+  }
+
+  groups.sort((a, b) => a.sectionOrder - b.sectionOrder);
+  return groups;
+}
+
+export function llmsIndexTemplate(args: LlmsIndexArgs): string {
+  const { siteName, siteDescription, baseUrl, pages, sectionsConfig } = args;
+  const lines: string[] = [];
+
+  lines.push(`# ${siteName}`);
+  lines.push("");
+  if (siteDescription && siteDescription.trim() !== "") {
+    lines.push(`> ${siteDescription.trim()}`);
+    lines.push("");
+  }
+
+  if (pages.length === 0) {
+    return lines.join("\n") + "\n";
+  }
+
+  const groups = buildSectionGroups(pages, sectionsConfig);
+
+  for (const group of groups) {
+    lines.push(`## ${group.sectionLabel}`);
+    lines.push("");
+
+    const useCategoryHeadings =
+      group.categories.length > 1 ||
+      (group.categories.length === 1 && group.categories[0].category !== "");
+
+    for (const cat of group.categories) {
+      if (useCategoryHeadings && cat.category !== "") {
+        lines.push(`### ${cat.category}`);
+        lines.push("");
+      }
+      for (const page of cat.pages) {
+        const url = pageUrl(page.slug, baseUrl);
+        const desc =
+          page.description && page.description.trim() !== ""
+            ? `: ${page.description.trim()}`
+            : "";
+        lines.push(`- [${page.title}](${url})${desc}`);
+      }
+      lines.push("");
+    }
+  }
+
+  return lines.join("\n").replace(/\n+$/, "\n");
+}

--- a/src/templates/llms/llmsPage.ts
+++ b/src/templates/llms/llmsPage.ts
@@ -1,0 +1,26 @@
+import type { PageWithBody } from "./llmsFull.js";
+
+function pageUrl(slug: string, baseUrl: string | null): string {
+  if (baseUrl) {
+    return slug === "" ? `${baseUrl}/` : `${baseUrl}/${slug}`;
+  }
+  return slug === "" ? "/" : `/${slug}`;
+}
+
+export function llmsPageTemplate(
+  page: PageWithBody,
+  baseUrl: string | null,
+): string {
+  const lines: string[] = [];
+  lines.push(`# ${page.title}`);
+  lines.push("");
+  if (page.description && page.description.trim() !== "") {
+    lines.push(`> ${page.description.trim()}`);
+    lines.push("");
+  }
+  lines.push(`Source: ${pageUrl(page.slug, baseUrl)}`);
+  lines.push("");
+  lines.push(page.body.trim());
+  lines.push("");
+  return lines.join("\n");
+}

--- a/src/templates/mdx/accordion.mdx.ts
+++ b/src/templates/mdx/accordion.mdx.ts
@@ -6,38 +6,43 @@ category: "Components"
 categoryOrder: 1
 order: 4
 ---
+
 # Accordion
+
 Interactive panels for toggling visibility of content.
 
 Accordion elements help organize information by letting users show or hide sections as needed. They’re an effective way to manage progressive disclosure and simplify navigation through dense or optional content.
 
 ## Accordion Usage
+
 You can use the Accordion component directly within your MDX files without any import. The following example shows a basic usage:
 
-~~~mdx
+\`\`\`\`mdx
 <Accordion title="What is MDX?">
     You can put any content in here, including other components, like code:
 
-   \`\`\`java HelloWorld.java
-    class HelloWorld {
-        public static void main(String[] args) {
-            System.out.println("Hello, World!");
-        }
-    }
-  \`\`\`
+\`\`\`java HelloWorld.java
+ class HelloWorld {
+     public static void main(String[] args) {
+         System.out.println("Hello, World!");
+     }
+ }
+\`\`\`
+
 </Accordion>
-~~~
+\`\`\`\`
 
 <Accordion title="What is MDX?">
     You can put any content in here, including other components, like code:
 
-   \`\`\`java HelloWorld.java
-    class HelloWorld {
-        public static void main(String[] args) {
-            System.out.println("Hello, World!");
-        }
-    }
-  \`\`\`
+\`\`\`java HelloWorld.java
+ class HelloWorld {
+     public static void main(String[] args) {
+         System.out.println("Hello, World!");
+     }
+ }
+\`\`\`
+
 </Accordion>
 
 ## Properties

--- a/src/templates/mdx/ai-assistant.mdx.ts
+++ b/src/templates/mdx/ai-assistant.mdx.ts
@@ -6,13 +6,17 @@ category: "Configuration"
 categoryOrder: 3
 order: 8
 ---
+
 # AI Assistant
+
 Doccupine supports AI integration to enhance your documentation experience. You can use OpenAI, Anthropic, or Google Gemini to power AI features in your documentation site. The AI assistant uses your documentation content as context, allowing users to ask questions about your docs and receive accurate answers based on the documentation.
 
 ## Setup
+
 To enable AI features, create an \`.env\` file in the directory where your website is generated. By default, this is the \`nextjs-app/\` directory.
 
 ## Configuration
+
 Create an \`.env\` file with the following configuration options:
 
 \`\`\`env
@@ -37,13 +41,17 @@ GOOGLE_API_KEY=your_google_api_key_here
 \`\`\`
 
 ## Provider Selection
+
 Set \`LLM_PROVIDER\` to one of the following values:
+
 - \`openai\` - Use OpenAI's models
 - \`anthropic\` - Use Anthropic's models
 - \`google\` - Use Google's models
 
 ## API Keys
+
 You need to set the API key that matches your chosen provider:
+
 - For OpenAI: Set \`OPENAI_API_KEY\`
 - For Anthropic: Set \`ANTHROPIC_API_KEY\`
 - For Google: Set \`GOOGLE_API_KEY\`
@@ -57,12 +65,15 @@ You need to set the API key that matches your chosen provider:
 </Callout>
 
 ## Using Anthropic with OpenAI
+
 If you want to use Anthropic as your LLM provider, you must also have an OpenAI API key set. Here's why:
 
 ### The Situation
+
 Anthropic (Claude) does not provide an embeddings API. They only offer chat/completion models, not text embeddings.
 
 Your RAG (Retrieval-Augmented Generation) system has two components:
+
 - **Chat/Completion** - Generates answers, works with Anthropic.
 - **Embeddings** - Creates vector representations of text for search, Anthropic doesn't provide this.
 
@@ -78,27 +89,33 @@ This hybrid approach allows you to leverage Anthropic's powerful chat models whi
 
 ## Default models
 
-| Provider | Chat model | Embedding model |
-|---|---|---|
-| OpenAI | \`gpt-4.1-nano\` | \`text-embedding-3-small\` |
-| Anthropic | \`claude-sonnet-4-5-20250929\` | OpenAI fallback |
-| Google | \`gemini-2.5-flash-lite\` | \`gemini-embedding-001\` |
+| Provider  | Chat model                   | Embedding model          |
+| --------- | ---------------------------- | ------------------------ |
+| OpenAI    | \`gpt-4.1-nano\`               | \`text-embedding-3-small\` |
+| Anthropic | \`claude-sonnet-4-5-20250929\` | OpenAI fallback          |
+| Google    | \`gemini-2.5-flash-lite\`      | \`gemini-embedding-001\`   |
 
 ## Optional Settings
 
 ### Chat Model
+
 Override the default chat model by uncommenting and setting \`LLM_CHAT_MODEL\`. You can use any available model from your chosen provider. For a complete list of available models, refer to the official documentation:
+
 - [OpenAI Models](https://platform.openai.com/docs/models)
 - [Anthropic Models](https://docs.anthropic.com/claude/docs/models-overview)
 - [Google Gemini Models](https://ai.google.dev/models/gemini)
 
 ### Embedding Model
+
 Override the default embedding model by uncommenting and setting \`LLM_EMBEDDING_MODEL\`. For a complete list of available embedding models, refer to the official documentation:
+
 - [OpenAI Embeddings](https://platform.openai.com/docs/guides/embeddings)
 - [Google Gemini Embeddings](https://ai.google.dev/gemini-api/docs/embeddings)
 - **Anthropic**: Anthropic doesn't provide embeddings. If you use Anthropic as your provider, Doccupine will fallback to OpenAI for embeddings.
 
 ### Temperature
+
 Control the randomness of AI responses by setting \`LLM_TEMPERATURE\` to a value between 0 and 1:
+
 - \`0\` - More deterministic and focused responses (default)
 - \`1\` - More creative and varied responses`;

--- a/src/templates/mdx/analytics.mdx.ts
+++ b/src/templates/mdx/analytics.mdx.ts
@@ -6,10 +6,13 @@ category: "Configuration"
 categoryOrder: 3
 order: 10
 ---
+
 # Analytics
+
 Track how users interact with your documentation using PostHog. Doccupine supports both client-side and server-side tracking out of the box, with a privacy-first proxy that routes analytics through your own domain.
 
 ## analytics.json
+
 Place an \`analytics.json\` at your project root (the same folder where you execute \`npx doccupine\`).
 
 \`\`\`json
@@ -33,21 +36,26 @@ Place an \`analytics.json\` at your project root (the same folder where you exec
 </Callout>
 
 ## What gets tracked
+
 When \`analytics.json\` is configured, Doccupine enables two layers of tracking:
 
 ### Client-side
+
 - **Page views**: Captured on every client-side navigation using Next.js router hooks.
 - **Page leave**: Automatically captured when a user navigates away from a page.
 
 ### Server-side
+
 - **Page views**: Captured in middleware on every page request, including the initial server render.
 - **Request metadata**: URL, pathname, host, referrer, and user agent are sent with each event.
 - **Smart filtering**: API routes, internal Next.js routes, and prefetch requests are automatically excluded.
 
 ## Privacy proxy
+
 Doccupine routes all analytics traffic through your documentation domain using Next.js rewrites. Instead of sending data directly to PostHog (which ad blockers may intercept), requests go through \`/ingest\` on your own domain and are proxied to PostHog.
 
 This means:
+
 - No third-party domains appear in network requests.
 - Ad blockers are less likely to interfere with tracking.
 - Your users' browsing data stays within your domain boundary before reaching PostHog.
@@ -55,12 +63,14 @@ This means:
 The proxy destinations are derived automatically from the \`host\` field in your configuration.
 
 ## Getting a PostHog key
+
 1. Sign up at [posthog.com](https://posthog.com) (free tier available).
 2. Create a new project.
 3. Go to **Project Settings** and copy the **Project API Key**.
 4. Paste it into your \`analytics.json\` as the \`posthog.key\` value.
 
 ## Behavior
+
 - **Placement**: Put \`analytics.json\` in the project root alongside \`config.json\` and \`theme.json\`.
 - **Hot reload**: Changes to \`analytics.json\` are picked up automatically in watch mode. The layout, middleware, and Next.js config are regenerated.
 - **Graceful degradation**: If \`analytics.json\` is missing, empty, or has an invalid configuration, no tracking code runs. Your site works exactly the same without it.
@@ -71,10 +81,11 @@ The proxy destinations are derived automatically from the \`host\` field in your
 </Callout>
 
 ## Regions
+
 PostHog offers two cloud regions. Set the \`host\` field accordingly:
 
-| Region | Host |
-|---|---|
+| Region   | Host                       |
+| -------- | -------------------------- |
 | US Cloud | \`https://us.i.posthog.com\` |
 | EU Cloud | \`https://eu.i.posthog.com\` |
 
@@ -106,7 +117,7 @@ If you omit the \`host\` field, it defaults to the US Cloud endpoint.
 \`\`\`
 
 ## Tips
+
 - **Start simple**: Add the config with just your key and verify events appear in your PostHog dashboard before customizing further.
 - **Check your dashboard**: After deploying, visit your PostHog project to confirm page view events are flowing in.
-- **Production only**: Consider adding \`analytics.json\` only in your production/deployment setup to avoid tracking local development traffic.
-`;
+- **Production only**: Consider adding \`analytics.json\` only in your production/deployment setup to avoid tracking local development traffic.`;

--- a/src/templates/mdx/buttons.mdx.ts
+++ b/src/templates/mdx/buttons.mdx.ts
@@ -6,12 +6,15 @@ category: "Components"
 categoryOrder: 1
 order: 7
 ---
+
 # Buttons
+
 A flexible action component supporting variants, sizes, icons, and links.
 
 Buttons help users initiate actions or navigate to other pages. Use variants to convey emphasis, size for hierarchy, and icons to add clarity.
 
 ## Button Usage
+
 You can use the Button component directly within your MDX files without any import. The following examples show basic usage:
 
 \`\`\`mdx
@@ -53,14 +56,19 @@ You can use the Button component directly within your MDX files without any impo
 ### With icon
 
 \`\`\`mdx
-<Button icon="arrow-right" iconPosition="left">With left icon</Button>
-<Button icon="arrow-right" iconPosition="right">With right icon</Button>
+<Button icon="arrow-right" iconPosition="left">
+  With left icon
+</Button>
+<Button icon="arrow-right" iconPosition="right">
+  With right icon
+</Button>
 \`\`\`
 
 <Button icon="arrow-right" iconPosition="left">With left icon</Button>
 <Button icon="arrow-right" iconPosition="right">With right icon</Button>
 
 ### As a link
+
 Buttons can render as links when you provide an \`href\`.
 
 \`\`\`mdx

--- a/src/templates/mdx/callouts.mdx.ts
+++ b/src/templates/mdx/callouts.mdx.ts
@@ -6,35 +6,28 @@ category: "Components"
 categoryOrder: 1
 order: 8
 ---
+
 # Callouts
+
 Make your content stand out by using callouts for extra emphasis.
 
 You can format them as Note, Warning, Info, Danger and Success.
 
 ## Callouts Usage
+
 You can use the Callouts component directly within your MDX files without any import. The following example shows a basic usage:
 
-~~~mdx
-<Callout type="note">
-  This is a note callout
-</Callout>
+\`\`\`mdx
+<Callout type="note">This is a note callout</Callout>
 
-<Callout type="warning">
-  This is a warning callout
-</Callout>
+<Callout type="warning">This is a warning callout</Callout>
 
-<Callout type="info">
-  This is an info callout
-</Callout>
+<Callout type="info">This is an info callout</Callout>
 
-<Callout type="danger">
-  This is a danger callout
-</Callout>
+<Callout type="danger">This is a danger callout</Callout>
 
-<Callout type="success">
- This is a success callout
-</Callout>
-~~~
+<Callout type="success">This is a success callout</Callout>
+\`\`\`
 
 <Callout type="note">
   This is a note callout

--- a/src/templates/mdx/cards.mdx.ts
+++ b/src/templates/mdx/cards.mdx.ts
@@ -6,19 +6,24 @@ category: "Components"
 categoryOrder: 1
 order: 6
 ---
+
 # Cards
+
 Duplicate a page or section with ease, then emphasize important information or links using customizable layouts and icons.
 
 Cards act as visual containers for your content, giving you flexibility to combine text, icons, images, and links in a clean and organized way.
 
 ## Cards Usage
+
 You can use the Cards component directly within your MDX files without any import. The following example shows a basic usage:
 
-~~~mdx
+\`\`\`mdx
 <Card title="Note" icon="badge-info">
-  Doccupine CLI is a command-line tool that helps you create and manage your Doccupine project. It provides a simple and intuitive interface for creating and configuring your project.
+  Doccupine CLI is a command-line tool that helps you create and manage your
+  Doccupine project. It provides a simple and intuitive interface for creating
+  and configuring your project.
 </Card>
-~~~
+\`\`\`
 
 <Card title="Note" icon="badge-info">
   Doccupine CLI is a command-line tool that helps you create and manage your Doccupine project. It provides a simple and intuitive interface for creating and configuring your project.
@@ -28,11 +33,11 @@ You can use the Cards component directly within your MDX files without any impor
 
 Pass a \`href\` prop to turn the card into a clickable link. The card will display interactive hover and focus styles automatically.
 
-~~~mdx
+\`\`\`mdx
 <Card title="Getting Started" icon="rocket" href="/cards">
   Learn how to set up Doccupine and create your first documentation site.
 </Card>
-~~~
+\`\`\`
 
 <Card title="Getting Started" icon="rocket" href="/cards">
   Learn how to set up Doccupine and create your first documentation site.

--- a/src/templates/mdx/code.mdx.ts
+++ b/src/templates/mdx/code.mdx.ts
@@ -6,13 +6,17 @@ category: "Components"
 categoryOrder: 1
 order: 3
 ---
+
 # Code
+
 Learn how to display inline code and code blocks in documentation.
 
 ## Adding Code Samples
+
 Both inline code snippets and full code blocks are supported. Code blocks offer customization for syntax highlighting and more to improve readability and user experience.
 
 ### Inline Code
+
 Highlight code within text by wrapping it with backticks:
 
 \`\`\`text
@@ -22,11 +26,12 @@ Enclose any \`word\` or \`phrase\` in backticks to format it as code.
 Enclose any \`word\` or \`phrase\` in backticks to format it as code.
 
 ## Code Blocks
+
 To present larger code samples, use triple backticks for fenced code blocks. Each block can be copied, and—if assistant features are enabled—users can request explanations.
 
 You may specify the language for highlighting:
 
-~~~text
+\`\`\`\`text
 \`\`\`java
 class HelloWorld {
     public static void main(String[] args) {
@@ -34,8 +39,7 @@ class HelloWorld {
     }
 }
 \`\`\`
-~~~
-
+\`\`\`\`
 
 \`\`\`java
 class HelloWorld {

--- a/src/templates/mdx/color-swatches.mdx.ts
+++ b/src/templates/mdx/color-swatches.mdx.ts
@@ -6,15 +6,18 @@ category: "Components"
 categoryOrder: 1
 order: 15
 ---
+
 # Color Swatches
+
 Display color palettes with labeled swatches to document your theme colors.
 
 The \`ColorSwatch\` component renders a visual preview of a color alongside its token name, and \`ColorSwatchGroup\` arranges multiple swatches in a responsive grid.
 
 ## Usage
+
 You can use the ColorSwatch components directly within your MDX files without any import:
 
-~~~mdx
+\`\`\`mdx
 <ColorSwatchGroup>
   <ColorSwatch token="primary" value="#6366F1" />
   <ColorSwatch token="secondary" value="#EC4899" />
@@ -23,7 +26,7 @@ You can use the ColorSwatch components directly within your MDX files without an
   <ColorSwatch token="danger" value="#EF4444" />
   <ColorSwatch token="info" value="#3B82F6" />
 </ColorSwatchGroup>
-~~~
+\`\`\`
 
 <ColorSwatchGroup>
   <ColorSwatch token="primary" value="#6366F1" />
@@ -38,7 +41,7 @@ You can use the ColorSwatch components directly within your MDX files without an
 
 Text color automatically adapts based on the background luminance, so dark swatches display white text:
 
-~~~mdx
+\`\`\`mdx
 <ColorSwatchGroup>
   <ColorSwatch token="dark" value="#1E1E2E" />
   <ColorSwatch token="grayDark" value="#374151" />
@@ -47,7 +50,7 @@ Text color automatically adapts based on the background luminance, so dark swatc
   <ColorSwatch token="light" value="#F9FAFB" />
   <ColorSwatch token="white" value="#FFFFFF" />
 </ColorSwatchGroup>
-~~~
+\`\`\`
 
 <ColorSwatchGroup>
   <ColorSwatch token="dark" value="#1E1E2E" />

--- a/src/templates/mdx/columns.mdx.ts
+++ b/src/templates/mdx/columns.mdx.ts
@@ -6,12 +6,15 @@ category: "Components"
 categoryOrder: 1
 order: 13
 ---
+
 # Columns
+
 Arrange multiple cards neatly in a side-by-side grid layout.
 
 The \`Columns\` component helps you organize several \`Card\` elements into a visually balanced grid. By choosing how many columns you want, you can control the layout and spacing of your cards.
 
 ## Columns Usage
+
 You can use the \`Columns\` component to create a grid of cards with a specified number of columns.
 
 \`\`\`mdx

--- a/src/templates/mdx/commands.mdx.ts
+++ b/src/templates/mdx/commands.mdx.ts
@@ -6,10 +6,13 @@ category: "Getting Started"
 categoryOrder: 0
 order: 1
 ---
+
 # Commands
+
 In this page, you can find all the commands available in Doccupine CLI.
 
 ## Run Doccupine CLI
+
 Create a new directory for your project and navigate to it in your terminal. Run the following command to create a new Doccupine project:
 
 \`\`\`bash
@@ -23,11 +26,11 @@ This will start the development server on port 3000. Open your browser and navig
 
 ## Options
 
-| Flag | Description |
-|---|---|
+| Flag            | Description                                                          |
+| --------------- | -------------------------------------------------------------------- |
 | \`--port <port>\` | Port for the dev server (default: \`3000\`). Auto-increments if taken. |
-| \`--verbose\` | Show all Next.js output including compilation details. |
-| \`--reset\` | Re-prompt for watch/output directories. |
+| \`--verbose\`     | Show all Next.js output including compilation details.               |
+| \`--reset\`       | Re-prompt for watch/output directories.                              |
 
 ## Verbose mode
 

--- a/src/templates/mdx/components.mdx.ts
+++ b/src/templates/mdx/components.mdx.ts
@@ -6,6 +6,7 @@ category: "Components"
 categoryOrder: 1
 order: 0
 ---
+
 # Components
 
 Doccupine includes a rich set of built-in components you can use directly in your MDX files - no imports needed. Browse the full library below.

--- a/src/templates/mdx/deployment-and-hosting.mdx.ts
+++ b/src/templates/mdx/deployment-and-hosting.mdx.ts
@@ -6,7 +6,9 @@ category: "Configuration"
 categoryOrder: 3
 order: 11
 ---
+
 # Deployment & Hosting
+
 The fastest way to deploy your documentation is with the [Doccupine Platform](https://www.doccupine.com). If you prefer to manage your own infrastructure, you can self-host the generated Next.js app on any platform.
 
 ## Doccupine Platform
@@ -18,6 +20,7 @@ Sign up at [doccupine.com](https://www.doccupine.com) and connect your repositor
 </Callout>
 
 ### What you get
+
 - **Automatic deployments** on every push to your repository
 - **Site customization** through a visual dashboard - no code changes needed
 - **Team collaboration** so your whole team can manage docs together
@@ -26,6 +29,7 @@ Sign up at [doccupine.com](https://www.doccupine.com) and connect your repositor
 - **Zero maintenance** - no servers, no build pipelines, no dependency updates
 
 ### Getting started
+
 1. Create an account at [doccupine.com](https://www.doccupine.com).
 2. Connect your GitHub repository.
 3. Your site is deployed automatically.
@@ -56,6 +60,7 @@ Doccupine generates a standard Next.js app, so you can deploy it anywhere that s
 - **Node.js server** - run \`next build && next start\` on any server or VPS with Node.js installed.
 
 ### Sitemap and robots.txt
+
 Doccupine generates \`sitemap.xml\` and \`robots.txt\` automatically when you set a site URL. This is required for search engine indexing and is strongly recommended for any public deployment.
 
 Set the URL in \`config.json\`:
@@ -75,6 +80,7 @@ NEXT_PUBLIC_SITE_URL=https://staging.example.com
 The generated sitemap includes every page from every [section](/sections), with \`lastModified\` derived from each page's frontmatter \`date\` or the file's modification time. When no URL is configured, the sitemap is skipped and \`robots.txt\` is emitted without a sitemap reference.
 
 ### Troubleshooting
+
 - **Build failed** - check build logs. Ensure your lockfile and correct Node.js version are present.
 - **Missing content** - verify your MDX files and assets are in the repository.
 - **SSR issues on edge platforms** - some features (like the AI chat API routes) require a Node.js runtime. Check your platform's documentation for SSR/API route support.`;

--- a/src/templates/mdx/fields.mdx.ts
+++ b/src/templates/mdx/fields.mdx.ts
@@ -6,12 +6,15 @@ category: "Components"
 categoryOrder: 1
 order: 11
 ---
+
 # Fields
+
 Configure parameters for your API or SDK documentation.
 
 Fields allow you to describe both the **inputs** (parameters) and **outputs** (responses) of your API. The main field component is available: \`Field\` for parameters and for responses.
 
 ## Fields Usage
+
 Use the \`<Field>\` component to declare API or SDK parameters, or define the return values of an API.
 
 <Field value="param" type="string" required>

--- a/src/templates/mdx/fonts.mdx.ts
+++ b/src/templates/mdx/fonts.mdx.ts
@@ -6,13 +6,17 @@ category: "Configuration"
 categoryOrder: 3
 order: 7
 ---
+
 # Fonts
+
 Define your site’s typography with a \`fonts.json\` file. You can load fonts from Google Fonts or from local font files bundled with your project.
 
 ## fonts.json
+
 Place a \`fonts.json\` at your project root (the same folder where you execute \`npx doccupine\`). Choose one of the following configurations depending on the source of your fonts.
 
 ## Google Fonts
+
 Use this when your font is hosted by Google Fonts.
 
 \`\`\`json
@@ -26,6 +30,7 @@ Use this when your font is hosted by Google Fonts.
 \`\`\`
 
 ### Rules
+
 - **fontName**: Capitalize each word. If the name contains spaces, replace them with \`_\`.
   - Example: "Work Sans" → \`Work_Sans\`
 - **subsets**: Pick the subsets you need (for example, \`latin\`).
@@ -36,10 +41,12 @@ Use this when your font is hosted by Google Fonts.
 </Callout>
 
 ### Tips
+
 - **One primary family**: Start with a single family and weight, then add more if needed.
 - **Readability**: Choose readable body fonts; reserve display fonts for headings.
 
 ## Local custom fonts
+
 Use this when you want to ship your own font files. Upload your font files to the Next.js \`public\` directory, then reference them with relative paths.
 
 \`\`\`json
@@ -72,6 +79,7 @@ Use this when you want to ship your own font files. Upload your font files to th
 \`\`\`
 
 ### Single file shorthand
+
 If you have only one file, you can use:
 
 \`\`\`json
@@ -81,16 +89,19 @@ If you have only one file, you can use:
 \`\`\`
 
 ### Rules
+
 - **Upload files**: Place \`font.woff\` (and any additional weights/styles) in your Next.js \`public\` directory.
 - **path**: Use a relative path to the file from where it is consumed by your build tooling; the example above uses \`../public/font.woff\`.
 - **weight**: String value of the font weight (for example, \`"400"\`, \`"700"\`).
 - **style**: \`"normal"\` or \`"italic"\`.
 
 ### Tips
+
 - **Provide only what you need**: Include the minimal set of weights/styles to keep bundle size small.
 - **File formats**: \`.woff\` is broadly supported and recommended for the web.
 
 ## Behavior
+
 - **Placement**: Put \`fonts.json\` in the project root alongside \`config.json\` and (optionally) \`theme.json\`.
 - **Validation**: Follow the naming rule for \`googleFont.fontName\` (capitalize, replace spaces with \`_\`).
 
@@ -99,6 +110,7 @@ If you have only one file, you can use:
 </Callout>
 
 ## Examples
+
 - **Google Fonts (single weight)**
 
 \`\`\`json
@@ -136,5 +148,4 @@ If you have only one file, you can use:
     ]
   }
 }
-\`\`\`
-`;
+\`\`\``;

--- a/src/templates/mdx/footer-links.mdx.ts
+++ b/src/templates/mdx/footer-links.mdx.ts
@@ -6,10 +6,13 @@ category: "Configuration"
 categoryOrder: 3
 order: 4
 ---
+
 # Footer Links
+
 Add a row of static links at the bottom of your documentation pages, just above the footer. Links open in a new tab and are useful for pointing users to related resources, repositories, or external docs.
 
 ## links.json
+
 Place a \`links.json\` at your project root (the same folder where you execute \`npx doccupine\`). When present, Doccupine displays the links at the bottom of each page. You can add as many links as you need.
 
 ### Example links.json
@@ -35,11 +38,13 @@ Place a \`links.json\` at your project root (the same folder where you execute \
 \`\`\`
 
 ### Fields
+
 - **title**: The label shown for the link.
 - **url**: The destination URL. Links open in a new tab with \`target="_blank"\` and \`rel="noopener noreferrer"\`.
 - **icon**: The icon to display next to the label. Icons are from [Lucide](https://lucide.dev/).
 
 ## Behavior
+
 - **Empty or missing file**: If \`links.json\` is empty or not present, the footer links are hidden.
 - **Order**: Links appear in the same order as in the array.
 - **No limit**: Add as many links as you want; they wrap automatically on smaller screens.`;

--- a/src/templates/mdx/globals.mdx.ts
+++ b/src/templates/mdx/globals.mdx.ts
@@ -12,10 +12,13 @@ category: "Configuration"
 categoryOrder: 3
 order: 1
 ---
+
 # Global Configuration
+
 Use a \`config.json\` file to define project‑wide metadata for your documentation site. These values are applied to every generated page unless a page overrides them in its own frontmatter.
 
 ## config.json
+
 Place a \`config.json\` at your project root (the same folder where you execute \`npx doccupine\`) to define global metadata for your documentation site.
 
 \`\`\`json
@@ -29,6 +32,7 @@ Place a \`config.json\` at your project root (the same folder where you execute 
 \`\`\`
 
 ## Fields
+
 All fields are optional. Doccupine uses sensible defaults when a field is not set.
 
 - **name**: The primary name of your documentation website. Displayed in the site title and used in various UI elements.
@@ -38,18 +42,19 @@ All fields are optional. Doccupine uses sensible defaults when a field is not se
 - **url**: The public URL of your deployed site. Used as the base URL for \`sitemap.xml\` and \`robots.txt\`. When omitted, no sitemap is generated. Can be overridden at deploy time with the \`NEXT_PUBLIC_SITE_URL\` environment variable.
 
 ## Per-page overrides
+
 Any page can override global values by defining the matching key in its frontmatter. When present, the page's value takes precedence over \`config.json\` for that page only.
 
-| Frontmatter field | Overrides | Effect |
-|---|---|---|
-| **title** | - | Page title in metadata and Open Graph |
-| **description** | \`description\` | Meta description and Open Graph description |
-| **name** | \`name\` | Site name shown in the title suffix (e.g. "Page - My Docs") |
-| **icon** | \`icon\` | Favicon for this page |
-| **image** | \`image\` | Open Graph preview image |
-| **section** | - | Assigns the page to a [section](/sections) |
-| **sectionOrder** | - | Controls section position in the tab bar |
-| **sectionLabel** | - | Renames the default "Docs" tab (use on \`index.mdx\`) |
+| Frontmatter field | Overrides     | Effect                                                      |
+| ----------------- | ------------- | ----------------------------------------------------------- |
+| **title**         | -             | Page title in metadata and Open Graph                       |
+| **description**   | \`description\` | Meta description and Open Graph description                 |
+| **name**          | \`name\`        | Site name shown in the title suffix (e.g. "Page - My Docs") |
+| **icon**          | \`icon\`        | Favicon for this page                                       |
+| **image**         | \`image\`       | Open Graph preview image                                    |
+| **section**       | -             | Assigns the page to a [section](/sections)                  |
+| **sectionOrder**  | -             | Controls section position in the tab bar                    |
+| **sectionLabel**  | -             | Renames the default "Docs" tab (use on \`index.mdx\`)         |
 
 <Callout type="note">
   If a key is not specified in a page's frontmatter, Doccupine falls back to the corresponding value in \`config.json\`.
@@ -67,6 +72,4 @@ image: "/custom-preview.png"
 date: "2026-02-19"
 category: "Guides"
 ---
-\`\`\`
-
-`;
+\`\`\``;

--- a/src/templates/mdx/headers-and-text.mdx.ts
+++ b/src/templates/mdx/headers-and-text.mdx.ts
@@ -6,13 +6,17 @@ category: "Components"
 categoryOrder: 1
 order: 1
 ---
+
 # Headers and Text
+
 Learn how to structure and style your content with headers, formatting, and links.
 
 ## Headers
+
 Headers define the hierarchy of your content and automatically generate navigation anchors. They also appear in the table of contents, helping readers quickly scan through documentation.
 
 ### Creating headers
+
 Add \`#\` symbols before text to create headers at various levels:
 
 \`\`\`text
@@ -22,16 +26,19 @@ Add \`#\` symbols before text to create headers at various levels:
 \`\`\`
 
 ## Text Formatting
+
 Markdown text styling is supported for emphasis, highlighting, and readability.
 
 ### Basic formatting
+
 Use these common syntax options:
 
 - Bold: \`**bold text**\` → **bold text**
-- Italic: \`*italic text*\` → *italic text*
+- Italic: \`*italic text*\` → _italic text_
 - Strikethrough: \`~~strikethrough~~\` → ~~strikethrough~~
 
 ### Combining formats
+
 You can mix multiple styles at once for clarity:
 
 \`\`\`text
@@ -41,15 +48,18 @@ You can mix multiple styles at once for clarity:
 \`\`\`
 
 ## Superscript and subscript
+
 For formulas, notes, or variables, use HTML tags:
 
 - Superscript \`X<sup>2</sup>\` → X<sup>2</sup>
 - Subscript \`H<sub>2</sub>O\` → H<sub>2</sub>O
 
 ## Links
+
 Links connect users to internal pages or external resources. Always use descriptive link text for better accessibility.
 
 ### Internal links
+
 Reference other docs with root-relative paths:
 
 \`\`\`text
@@ -61,6 +71,7 @@ Reference other docs with root-relative paths:
 - [Commands](/commands)
 
 ### External links
+
 Point to external pages by including full URLs:
 
 \`\`\`text
@@ -70,9 +81,11 @@ Point to external pages by including full URLs:
 [Markdown Guide](https://www.markdownguide.org/)
 
 ## Blockquotes
+
 Blockquotes are used to visually highlight key information, quotations, or examples.
 
 ### Single line blockquotes
+
 Prefix text with \`>\` for a single-line blockquote:
 
 \`\`\`text
@@ -82,6 +95,7 @@ Prefix text with \`>\` for a single-line blockquote:
 > Highlighted message or quote
 
 ### Multi-line blockquotes
+
 For larger quotes spanning more than one paragraph:
 
 \`\`\`text
@@ -95,9 +109,11 @@ For larger quotes spanning more than one paragraph:
 > Each new line starts with a \`>\` symbol.
 
 ## Line Breaks and Spacing
+
 Control spacing to improve readability and layout.
 
 ### Paragraph breaks
+
 Separate paragraphs with blank lines:
 
 \`\`\`text
@@ -111,6 +127,7 @@ First paragraph.
 Second paragraph.
 
 ## Manual line breaks
+
 For shorter breaks inside the same paragraph, use \`<br />\`:
 
 \`\`\`text
@@ -124,16 +141,19 @@ This is the next line.
 # Best Practices
 
 ## Organizing content
+
 - Use headers to establish hierarchy
 - Maintain logical order (avoid skipping levels, e.g., H2 → H4)
 - Always write meaningful, descriptive headers
 
 ## Formatting text
+
 - Use **bold** for key emphasis only
-- Use *italics* for emphasis or technical terms
+- Use _italics_ for emphasis or technical terms
 - Limit formatting combinations to maintain readability
 
 ## Links usage
+
 - Avoid vague text like “click here”
 - Prefer root-relative paths for internal links
 - Regularly validate links to ensure they are not broken`;

--- a/src/templates/mdx/icons.mdx.ts
+++ b/src/templates/mdx/icons.mdx.ts
@@ -6,7 +6,9 @@ category: "Components"
 categoryOrder: 1
 order: 10
 ---
+
 # Icons
+
 Integrate visual icons from well-known libraries to enrich your documentation.
 
 Icons can be sourced from Lucide, SVG elements, external URLs, or local files within your project directory.
@@ -18,6 +20,7 @@ Icons can be sourced from Lucide, SVG elements, external URLs, or local files wi
 \`\`\`
 
 ## Inline icons
+
 You can use icons directly within text to highlight information or add visual context.
 
 <Icon name="flag" size={16} /> Build your documentation seamlessly.

--- a/src/templates/mdx/image-and-embeds.mdx.ts
+++ b/src/templates/mdx/image-and-embeds.mdx.ts
@@ -6,7 +6,9 @@ category: "Components"
 categoryOrder: 1
 order: 9
 ---
+
 # Images and embeds
+
 Enrich your documentation with visuals, videos, and interactive embeds.
 
 Display images, embed video content, or add interactive frames via iframes to supplement your docs.
@@ -14,9 +16,11 @@ Display images, embed video content, or add interactive frames via iframes to su
 ![Demo Image](https://docs.doccupine.com/demo.png)
 
 ## Images
+
 Images enhance documentation with context, illustration, or decorative visual cues.
 
 ### Basic Image Syntax
+
 Include an image in Markdown using the syntax below:
 
 \`\`\`md
@@ -28,6 +32,7 @@ Include an image in Markdown using the syntax below:
 </Callout>
 
 ### HTML image embeds
+
 Embed images in your Markdown content using HTML syntax.
 
 \`\`\`md
@@ -35,6 +40,7 @@ Embed images in your Markdown content using HTML syntax.
 \`\`\`
 
 ### Theme-aware images
+
 Show different images depending on whether the user is in light or dark mode. Add the \`light-only\` or \`dark-only\` className to display an image exclusively in that theme.
 
 \`\`\`md
@@ -50,9 +56,11 @@ Show different images depending on whether the user is in light or dark mode. Ad
 </Callout>
 
 ## Videos
+
 Videos add a dynamic element to your documentation, engaging your audience and providing a more immersive experience.
 
 ### YouTube Embed
+
 To embed a YouTube video, use the following syntax:
 
 \`\`\`html
@@ -60,9 +68,9 @@ To embed a YouTube video, use the following syntax:
   className="aspect-video"
   src="https://www.youtube.com/embed/ResP_eVPYQo"
   title="YouTube video player"
-  frameBorder="0"
+  frameborder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowFullScreen
+  allowfullscreen
 ></iframe>
 \`\`\`
 
@@ -76,6 +84,7 @@ To embed a YouTube video, use the following syntax:
 ></iframe>
 
 ### Self-hosted videos
+
 Serve up your own video content using the \`<video>\` tag:
 
 \`\`\`html
@@ -87,13 +96,14 @@ Serve up your own video content using the \`<video>\` tag:
 \`\`\`
 
 <video
-  controls
-  className="aspect-video"
-  src="https://samplelib.com/lib/preview/mp4/sample-20s.mp4"
-></video>
+controls
+className="aspect-video"
+src="https://samplelib.com/lib/preview/mp4/sample-20s.mp4"
 
+> </video>
 
 #### Autoplay and Looping
+
 For demonstration videos that loop or start automatically, add attributes as shown:
 
 \`\`\`html
@@ -101,10 +111,9 @@ For demonstration videos that loop or start automatically, add attributes as sho
   controls
   className="aspect-video"
   src="https://samplelib.com/lib/preview/mp4/sample-20s.mp4"
-  autoPlay
+  autoplay
   muted
   loop
-  playsInline
+  playsinline
 ></video>
-\`\`\`
-`;
+\`\`\``;

--- a/src/templates/mdx/index.mdx.ts
+++ b/src/templates/mdx/index.mdx.ts
@@ -8,6 +8,7 @@ category: "Getting Started"
 categoryOrder: 0
 order: 0
 ---
+
 # Welcome to Doccupine
 
 Doccupine turns a folder of MDX files into a beautiful, production-ready documentation website. Write in standard Markdown, use any of the built-in components, and get a fully themed site with AI-powered search and automatic navigation - all from one command.
@@ -46,5 +47,4 @@ Doccupine works with no configuration, but when you're ready to customize, every
 - [Theme](/theme) - Colors, logos, and dark mode palette via \`theme.json\`
 - [Fonts](/fonts) - Google Fonts or local font files via \`fonts.json\`
 - [AI Assistant](/ai-assistant) - Enable the built-in chat with your own API key
-- [MCP Server](/model-context-protocol) - Let AI tools search your docs through \`/api/mcp\`
-`;
+- [MCP Server](/model-context-protocol) - Let AI tools search your docs through \`/api/mcp\``;

--- a/src/templates/mdx/lists-and-tables.mdx.ts
+++ b/src/templates/mdx/lists-and-tables.mdx.ts
@@ -6,13 +6,17 @@ category: "Components"
 categoryOrder: 1
 order: 2
 ---
+
 # Lists and Tables
+
 Present structured information using lists or tables.
 
 ## Lists
-Markdown supports both *ordered* and *unordered* lists, as well as nested list structures.
+
+Markdown supports both _ordered_ and _unordered_ lists, as well as nested list structures.
 
 ### Ordered List
+
 Start each item with a number followed by a period to create an ordered list.
 
 \`\`\`md
@@ -27,8 +31,8 @@ Start each item with a number followed by a period to create an ordered list.
 3. Third item
 4. Fourth item
 
-
 ### Unordered List
+
 Use dashes (\`-\`), asterisks (\`*\`), or plus signs (\`+\`) before each item for unordered lists.
 
 \`\`\`md
@@ -44,6 +48,7 @@ Use dashes (\`-\`), asterisks (\`*\`), or plus signs (\`+\`) before each item fo
 - Fourth item
 
 ### Nested List
+
 Indent items under another to create nested lists.
 
 \`\`\`md
@@ -61,6 +66,7 @@ Indent items under another to create nested lists.
 - Third item
 
 ## Tables
+
 Markdown tables use pipes (\`|\`) to separate columns and hyphens (\`---\`) to define the header row. Place a pipe at the start and end of each row for better compatibility.
 
 \`\`\`md

--- a/src/templates/mdx/media-and-assets.mdx.ts
+++ b/src/templates/mdx/media-and-assets.mdx.ts
@@ -6,10 +6,13 @@ category: "Configuration"
 categoryOrder: 3
 order: 6
 ---
+
 # Media and assets
+
 Doccupine watches a \`public\` directory in your project root (the same folder where you execute \`npx doccupine\`) and copies its contents into the generated Next.js \`public\` folder. Use it to serve static files such as favicons, Open Graph preview images, custom fonts, or any other media your documentation needs.
 
 ## The public directory
+
 Create a \`public\` folder at your project root. Any file you place inside is automatically synced to the generated site and served from the root URL path.
 
 \`\`\`text
@@ -27,18 +30,20 @@ my-docs/
 \`\`\`
 
 ## How assets are served
+
 Files in the \`public\` directory are available at the root of your deployed domain. The path inside \`public\` maps directly to the URL path.
 
-| File                          | URL                                        |
-|-------------------------------|--------------------------------------------|
-| \`public/favicon.ico\`         | \`https://your-domain.com/favicon.ico\`     |
-| \`public/og-image.png\`        | \`https://your-domain.com/og-image.png\`    |
-| \`public/logo.svg\`            | \`https://your-domain.com/logo.svg\`        |
+| File                             | URL                                               |
+| -------------------------------- | ------------------------------------------------- |
+| \`public/favicon.ico\`             | \`https://your-domain.com/favicon.ico\`             |
+| \`public/og-image.png\`            | \`https://your-domain.com/og-image.png\`            |
+| \`public/logo.svg\`                | \`https://your-domain.com/logo.svg\`                |
 | \`public/fonts/custom-font.woff2\` | \`https://your-domain.com/fonts/custom-font.woff2\` |
 
 ## Common use cases
 
 ### Favicon
+
 Drop a \`favicon.ico\` into the \`public\` folder. Browsers pick it up automatically from the root path.
 
 \`\`\`text
@@ -46,6 +51,7 @@ public/favicon.ico → https://your-domain.com/favicon.ico
 \`\`\`
 
 ### Open Graph preview image
+
 Add an image for link previews on social media. Reference it in your \`config.json\` so Doccupine sets the correct meta tags.
 
 \`\`\`text
@@ -53,6 +59,7 @@ public/og-image.png → https://your-domain.com/og-image.png
 \`\`\`
 
 ### Custom fonts
+
 Place font files in \`public\` and reference them from your \`fonts.json\`. See the **Fonts** page for full configuration details.
 
 \`\`\`text
@@ -60,6 +67,7 @@ public/fonts/custom-font.woff2 → https://your-domain.com/fonts/custom-font.wof
 \`\`\`
 
 ### Images and other media
+
 Any image or file you want to reference in your MDX pages can live in \`public\`. Use a root-relative path in your content:
 
 \`\`\`mdx
@@ -73,6 +81,7 @@ Any image or file you want to reference in your MDX pages can live in \`public\`
 </Callout>
 
 ## Tips
+
 - **Keep it flat**: For a small number of files, placing them directly in \`public\` keeps paths short and simple.
 - **Use subfolders for organization**: For larger projects, group assets into folders like \`public/fonts\`, \`public/images\`, or \`public/icons\`.
 - **Mind file size**: Optimize images before adding them to keep deployment size and load times low.

--- a/src/templates/mdx/model-context-protocol.mdx.ts
+++ b/src/templates/mdx/model-context-protocol.mdx.ts
@@ -6,7 +6,9 @@ category: "Configuration"
 categoryOrder: 3
 order: 9
 ---
+
 # Model Context Protocol
+
 Connect your documentation to AI tools with a hosted MCP server.
 
 Doccupine automatically generates a Model Context Protocol (MCP) server from your documentation, making your content accessible to AI applications like Claude, Cursor, VS Code, and other MCP-compatible tools. Your MCP server exposes semantic search capabilities, allowing AI tools to query your documentation directly and provide accurate, context-aware answers.
@@ -25,18 +27,18 @@ Your MCP server exposes search and retrieval tools for AI applications to query 
 
 When an AI tool has your documentation MCP server connected, the AI tool can search your documentation directly instead of making a generic web search in response to a user's prompt. Your MCP server provides access to all indexed content from your documentation site.
 
-* The LLM can proactively search your documentation while generating a response, not just when explicitly asked.
-* The LLM determines when to use the search tool based on the context of the conversation and the relevance of your documentation.
-* Each tool call happens during the generation process, so the LLM searches up-to-date information from your documentation to generate its response.
+- The LLM can proactively search your documentation while generating a response, not just when explicitly asked.
+- The LLM determines when to use the search tool based on the context of the conversation and the relevance of your documentation.
+- Each tool call happens during the generation process, so the LLM searches up-to-date information from your documentation to generate its response.
 
 ### MCP compared to web search
 
 AI tools can search the web, but MCP provides distinct advantages for documentation.
 
-* **Direct source access**: Web search depends on what search engines have indexed, which may be stale or incomplete. MCP searches your current indexed documentation directly.
-* **Integrated workflow**: MCP allows the AI to search during response generation rather than performing a separate web search.
-* **Semantic search**: MCP uses vector embeddings for semantic similarity search, providing more relevant results than keyword-based web search.
-* **No search noise**: SEO and ranking algorithms influence web search results. MCP goes straight to your documentation content.
+- **Direct source access**: Web search depends on what search engines have indexed, which may be stale or incomplete. MCP searches your current indexed documentation directly.
+- **Integrated workflow**: MCP allows the AI to search during response generation rather than performing a separate web search.
+- **Semantic search**: MCP uses vector embeddings for semantic similarity search, providing more relevant results than keyword-based web search.
+- **No search noise**: SEO and ranking algorithms influence web search results. MCP goes straight to your documentation content.
 
 ## Access your MCP server
 
@@ -71,6 +73,7 @@ Requests without a valid token receive a \`401 Unauthorized\` response. When \`D
 Returns information about available tools and the current index status.
 
 **Response:**
+
 \`\`\`json
 {
   "tools": [
@@ -93,6 +96,7 @@ Returns information about available tools and the current index status.
 Executes an MCP tool call.
 
 **Request Body:**
+
 \`\`\`json
 {
   "tool": "search_docs",
@@ -104,6 +108,7 @@ Executes an MCP tool call.
 \`\`\`
 
 **Response:**
+
 \`\`\`json
 {
   "content": [
@@ -127,10 +132,12 @@ Your MCP server exposes three tools for interacting with your documentation:
 Search through the documentation content using semantic search. Returns relevant chunks of documentation based on the query using vector embeddings and cosine similarity.
 
 **Parameters:**
+
 - \`query\` (required): The search query to find relevant documentation
 - \`limit\` (optional): Maximum number of results to return (default: 6)
 
 **Example:**
+
 \`\`\`json
 {
   "tool": "search_docs",
@@ -146,9 +153,11 @@ Search through the documentation content using semantic search. Returns relevant
 Get the full content of a specific documentation page by its path.
 
 **Parameters:**
+
 - \`path\` (required): The file path to the documentation page (e.g., \`app/getting-started/page.tsx\`)
 
 **Example:**
+
 \`\`\`json
 {
   "tool": "get_doc",
@@ -163,9 +172,11 @@ Get the full content of a specific documentation page by its path.
 List all available documentation pages, optionally filtered by directory.
 
 **Parameters:**
+
 - \`directory\` (optional): Optional directory to filter results (e.g., \`components\`)
 
 **Example:**
+
 \`\`\`json
 {
   "tool": "list_docs",
@@ -293,10 +304,10 @@ These are some of the ways you can help your users connect to your MCP server:
 
 To use the MCP server, you need to have the AI Assistant configured. The MCP server uses the same LLM configuration for generating embeddings.
 
-| Variable | Required | Description |
-|---|---|---|
-| \`LLM_PROVIDER\` | Yes | Your LLM provider (\`openai\`, \`anthropic\`, or \`google\`) |
-| \`DOCS_API_KEY\` | No | When set, requires Bearer token authentication on \`/api/mcp\` |
+| Variable       | Required | Description                                                  |
+| -------------- | -------- | ------------------------------------------------------------ |
+| \`LLM_PROVIDER\` | Yes      | Your LLM provider (\`openai\`, \`anthropic\`, or \`google\`)       |
+| \`DOCS_API_KEY\` | No       | When set, requires Bearer token authentication on \`/api/mcp\` |
 
 <Callout type="warning">
   The MCP server requires an LLM provider to be configured for generating embeddings. Make sure you have set up your AI Assistant with a valid API key before using the MCP server.
@@ -313,6 +324,7 @@ Your MCP server searches content extracted from your page files. The server auto
 The server extracts content from \`const content =\` declarations in your page files. Make sure your documentation pages export a \`content\` constant with your markdown or MDX content.
 
 **Example:**
+
 \`\`\`tsx
 export const content = \`
 # Getting Started
@@ -324,6 +336,7 @@ Welcome to the documentation...
 ### Excluded directories
 
 The following directories are automatically excluded from indexing:
+
 - \`node_modules\`
 - \`.next\`
 - \`.git\`
@@ -334,6 +347,7 @@ The following directories are automatically excluded from indexing:
 ### Index not building
 
 If the index is not building, check:
+
 - Your LLM provider is configured correctly in your \`.env\` file
 - You have a valid API key set
 - Your documentation pages export a \`content\` constant
@@ -341,6 +355,7 @@ If the index is not building, check:
 ### No search results
 
 If searches return no results:
+
 - Verify that your documentation pages are in the \`app/\` directory
 - Check that your pages export a \`content\` constant
 - Ensure the index has been built (check the \`index.ready\` status via GET \`/api/mcp\`)
@@ -348,6 +363,7 @@ If searches return no results:
 ### Slow search performance
 
 The first search may be slower as it builds the index. Subsequent searches are fast as they use the in-memory index. If performance is consistently slow:
+
 - Check your embedding API response times
 - Consider reducing the number of documentation pages
 - Verify your server has sufficient memory
@@ -382,7 +398,7 @@ In Cloudflare dashboard:
 
 ## Best practices
 
-* **Keep content up-to-date**: Restart your server after updating documentation to rebuild the index with fresh content.
-* **Use descriptive queries**: More specific queries yield better semantic search results.
-* **Monitor index status**: Use the GET endpoint to check if your index is ready before performing searches.
-* **Optimize content structure**: Well-structured markdown with clear headings improves search relevance.`;
+- **Keep content up-to-date**: Restart your server after updating documentation to rebuild the index with fresh content.
+- **Use descriptive queries**: More specific queries yield better semantic search results.
+- **Monitor index status**: Use the GET endpoint to check if your index is ready before performing searches.
+- **Optimize content structure**: Well-structured markdown with clear headings improves search relevance.`;

--- a/src/templates/mdx/navigation.mdx.ts
+++ b/src/templates/mdx/navigation.mdx.ts
@@ -6,13 +6,17 @@ category: "Configuration"
 categoryOrder: 3
 order: 2
 ---
+
 # Navigation
+
 Doccupine builds your sidebar automatically from your MDX pages. By default, it reads the page frontmatter and groups pages into categories in the order you define. For larger docs, you can take full control with a \`navigation.json\` file.
 
 ## Automatic navigation (default)
+
 When no custom navigation is provided, Doccupine generates a structure based on each page's frontmatter.
 
 ### Frontmatter fields
+
 - **category**: The category name that groups the page in the sidebar.
 - **categoryOrder**: The position of the category within the sidebar. Lower numbers appear first.
 - **order**: The position of the page within its category. Lower numbers appear first.
@@ -33,9 +37,11 @@ order: 2
 This approach is great for small sets of documents. For larger projects, setting these fields on every page can become repetitive.
 
 ## Custom navigation with navigation.json
+
 To centrally define the entire sidebar, create a \`navigation.json\` at your project root (the same folder where you execute \`npx doccupine\`). When present, it takes priority over page frontmatter and fully controls the navigation structure.
 
 ### Array format
+
 The simplest format is an array of categories. When using [sections](/sections), this applies to the root section only.
 
 \`\`\`json
@@ -88,6 +94,7 @@ The simplest format is an array of categories. When using [sections](/sections),
 \`\`\`
 
 ### Object format (per-section)
+
 When using [sections](/sections), you can define navigation for each section by using an object keyed by section slug. Sections without a key fall back to auto-generated navigation from frontmatter.
 
 \`\`\`json
@@ -116,6 +123,7 @@ When using [sections](/sections), you can define navigation for each section by 
 The key \`""\` controls the root section. Other keys match section slugs defined in \`sections.json\` or derived from frontmatter. See [Sections](/sections) for details on configuring sections.
 
 ### Fields
+
 - **label**: The section header shown in the sidebar.
 - **links**: An array of page entries for that section.
   - **slug**: The MDX file slug (filename without extension). Use an empty string \`""\` for \`index.mdx\`.
@@ -132,6 +140,7 @@ The key \`""\` controls the root section. Other keys match section slugs defined
 - Pages without a \`category\` appear at the top level.
 
 ## Tips
+
 - **Start simple**: Use frontmatter for small docs. Switch to \`navigation.json\` as the structure grows.
 - **Keep slugs consistent**: \`slug\` must match the MDX filename (e.g., \`text.mdx\` -> \`text\`).
 - **Control titles**: Use \`title\` in \`navigation.json\` to customize sidebar labels without changing page frontmatter.

--- a/src/templates/mdx/platform/ai-assistant.mdx.ts
+++ b/src/templates/mdx/platform/ai-assistant.mdx.ts
@@ -7,12 +7,15 @@ categoryOrder: 2
 order: 6
 section: "Platform"
 ---
+
 # AI Assistant
+
 Every Doccupine site ships with a built-in AI assistant that helps visitors find answers across your documentation. The AI settings page lets you choose how it's powered.
 
 ## Modes
 
 ### Platform (default)
+
 Uses Doccupine's built-in integration. Zero configuration needed - the AI assistant works out of the box with no API keys or setup.
 
 Each plan includes a monthly AI usage budget:
@@ -36,6 +39,7 @@ If you run out of AI credits before your billing cycle resets, you can purchase 
 Top-ups are added to your current cycle's budget immediately after purchase and reset when your billing cycle renews. You can purchase multiple top-ups in the same cycle.
 
 ### Custom
+
 Bring your own API key for full control over the AI model. Supported providers:
 
 - **OpenAI**
@@ -43,12 +47,14 @@ Bring your own API key for full control over the AI model. Supported providers:
 - **Google**
 
 In Custom mode, you can also configure:
+
 - **Embedding model** - the model used to index your documentation content
 - **Temperature** - controls response creativity (0.0 for focused answers, up to 1.0 for more varied responses)
 
 For a complete list of available models, refer to the official documentation of your chosen provider.
 
 ### Off
+
 Completely disables the AI assistant on your site.
 
 <Callout type="warning">
@@ -56,6 +62,7 @@ Completely disables the AI assistant on your site.
 </Callout>
 
 ## MCP server authentication
+
 Every Doccupine site exposes an MCP (Model Context Protocol) endpoint at \`/api/mcp\`. This lets external AI tools query your documentation programmatically.
 
 You can set an optional **API key** to restrict access to the MCP endpoint. When set, requests must include the key in their authorization header.

--- a/src/templates/mdx/platform/analytics.mdx.ts
+++ b/src/templates/mdx/platform/analytics.mdx.ts
@@ -7,29 +7,36 @@ categoryOrder: 2
 order: 3
 section: "Platform"
 ---
+
 # Analytics
+
 The Analytics settings page lets you add PostHog analytics to your documentation site. Page views are tracked client-side and proxied through your own domain for privacy - no data is sent directly to PostHog.
 
 ## Enabling analytics
+
 Use the **Enable Analytics** toggle to turn tracking on or off. When disabled, no tracking code is added to your site.
 
 ## Configuration
 
 ### PostHog Project API Key
+
 Your project API key from PostHog (starts with \`phc_\`). This is a public identifier and is safe to commit to your repository.
 
 To find your key:
+
 1. Log in to [PostHog](https://posthog.com).
 2. Open your project settings.
 3. Copy the **Project API Key**.
 
 ### Region
+
 Select the PostHog cloud region that matches your project:
 
 - **US Cloud** - \`us.i.posthog.com\`
 - **EU Cloud** - \`eu.i.posthog.com\`
 
 ## How it works
+
 Analytics settings are stored in \`analytics.json\` at the root of your repository. Here's an example:
 
 \`\`\`json

--- a/src/templates/mdx/platform/billing.mdx.ts
+++ b/src/templates/mdx/platform/billing.mdx.ts
@@ -7,10 +7,13 @@ categoryOrder: 4
 order: 1
 section: "Platform"
 ---
+
 # Billing
+
 Doccupine offers a free trial and two paid plans. The Billing settings page lets you manage your subscription and access the Stripe billing portal.
 
 ## Free trial
+
 Every new account starts with a **30-day free trial** - no credit card required. During the trial, you have full access to all platform features.
 
 <Callout type="note">
@@ -20,16 +23,19 @@ Every new account starts with a **30-day free trial** - no credit card required.
 ## Plans
 
 ### Pro - \\$200/month
+
 - 1 project
 - Up to 5 team members
 - All platform features
 
 ### Enterprise - \\$500/month
+
 - 6 projects
 - Unlimited team members
 - All platform features
 
 ## Managing your subscription
+
 Click **Manage Billing** on the Billing settings page to open the Stripe billing portal. From there you can:
 
 - Update your payment method
@@ -38,7 +44,9 @@ Click **Manage Billing** on the Billing settings page to open the Stripe billing
 - Cancel your subscription
 
 ## Cancellation
+
 If you cancel your subscription, your projects enter a grace period. They are not deleted immediately, giving you time to re-subscribe if you change your mind.
 
 ## Who can access billing
+
 Billing is accessible to the project **owner** and any team members with the **Billing** role.`;

--- a/src/templates/mdx/platform/build-and-deploy.mdx.ts
+++ b/src/templates/mdx/platform/build-and-deploy.mdx.ts
@@ -7,10 +7,13 @@ categoryOrder: 3
 order: 1
 section: "Platform"
 ---
+
 # Build & Deploy
+
 The Build & Deploy page shows your documentation site's build and deployment history. Every time you publish changes or push to GitHub, a new deployment is created.
 
 ## Deployment status
+
 The project header always shows your current deployment status:
 
 - **Ready** - your site is live and up to date
@@ -23,9 +26,11 @@ The project header always shows your current deployment status:
 </Callout>
 
 ## Build logs
+
 Click on any deployment to view its build logs. These show the full output of the build process, making it easy to diagnose issues.
 
 ## Deployment triggers
+
 Deployments are triggered in three ways:
 
 1. **Publishing from Doccupine** - clicking Publish in the project header
@@ -33,4 +38,5 @@ Deployments are triggered in three ways:
 3. **Configuration changes** - saving AI assistant settings triggers a redeploy since those are stored as environment variables
 
 ## Visiting your site
+
 Click the **Visit** button in the project header to open your live documentation site in a new tab.`;

--- a/src/templates/mdx/platform/creating-a-project.mdx.ts
+++ b/src/templates/mdx/platform/creating-a-project.mdx.ts
@@ -7,16 +7,21 @@ categoryOrder: 0
 order: 1
 section: "Platform"
 ---
+
 # Creating a Project
+
 From your dashboard, click **Create new project** to get started. You'll name your project and choose how its Git repository is managed.
 
 ## Repository modes
+
 Doccupine needs a GitHub repository to store your documentation files. You have two options:
 
 ### Managed repository
+
 Choose **Use managed repository** and Doccupine creates and manages the GitHub repo for you under its own organization. This is the simplest option - no GitHub account required on your end.
 
 ### User repository
+
 Choose **Connect to GitHub** to link your own GitHub account via OAuth. Doccupine creates the repo in your account, giving you full ownership and direct access to the source files.
 
 <Callout type="note">
@@ -24,6 +29,7 @@ Choose **Connect to GitHub** to link your own GitHub account via OAuth. Doccupin
 </Callout>
 
 ## What happens during setup
+
 After you choose a repository mode, Doccupine runs an automated setup process:
 
 1. Creates a GitHub repository
@@ -39,6 +45,7 @@ This takes about a minute. Once complete, you're redirected to your new project'
 </Callout>
 
 ## Project limits
+
 The number of projects you can create depends on your plan:
 
 - **Pro** - 1 project, up to 5 team members

--- a/src/templates/mdx/platform/custom-domains.mdx.ts
+++ b/src/templates/mdx/platform/custom-domains.mdx.ts
@@ -7,7 +7,9 @@ categoryOrder: 3
 order: 0
 section: "Platform"
 ---
+
 # Custom Domains
+
 By default, your documentation site is available at a \`.doccupine.app\` subdomain. You can connect your own custom domain for a branded experience.
 
 ## Adding a domain
@@ -19,6 +21,7 @@ By default, your documentation site is available at a \`.doccupine.app\` subdoma
 Doccupine will provide DNS records that you need to configure with your domain registrar.
 
 ## DNS configuration
+
 After adding your domain, you'll see the required DNS records. Typically this involves adding a **CNAME** record pointing to your Doccupine deployment.
 
 Configure the records with your domain registrar (Cloudflare, Namecheap, GoDaddy, Route 53, etc.) and return to the Domains page to check verification status.
@@ -28,7 +31,9 @@ Configure the records with your domain registrar (Cloudflare, Namecheap, GoDaddy
 </Callout>
 
 ## Verification
+
 Doccupine periodically checks whether your DNS records are configured correctly. The Domains page shows the current verification status. Once verified, your custom domain is active and serves your documentation with automatic HTTPS.
 
 ## Removing a domain
+
 Click the remove button next to your domain to disconnect it. Your site will continue to be available at its \`.doccupine.app\` URL.`;

--- a/src/templates/mdx/platform/external-links.mdx.ts
+++ b/src/templates/mdx/platform/external-links.mdx.ts
@@ -7,10 +7,13 @@ categoryOrder: 2
 order: 5
 section: "Platform"
 ---
+
 # External Links
+
 The External Links settings page lets you add external link buttons to your documentation site's footer. These provide quick access to your project's GitHub repository, Discord server, social profiles, and other resources.
 
 ## Adding a link
+
 Click **Add Link** and configure:
 
 - **Icon** (optional) - search and pick from any [Lucide](https://lucide.dev/) icon
@@ -18,6 +21,7 @@ Click **Add Link** and configure:
 - **URL** - the target URL
 
 ## Choosing an icon
+
 The icon picker lets you search through the full [Lucide](https://lucide.dev/) icon set. Type a keyword to filter (e.g. "git-branch", "mail", "globe") and click to select.
 
 Leave the icon unset for a text-only link.
@@ -25,6 +29,7 @@ Leave the icon unset for a text-only link.
 If you edit \`links.json\` directly, use Lucide icon names in kebab-case (e.g. \`git-branch\`, \`message-circle\`, \`heart\`).
 
 ## How it works
+
 Link settings are stored in \`links.json\` at the root of your repository:
 
 \`\`\`json

--- a/src/templates/mdx/platform/file-editor.mdx.ts
+++ b/src/templates/mdx/platform/file-editor.mdx.ts
@@ -7,10 +7,13 @@ categoryOrder: 1
 order: 0
 section: "Platform"
 ---
+
 # File Editor
+
 The file editor is the main workspace for your documentation project. It provides a browser-based file explorer and editor for working with your MDX files and assets.
 
 ## File explorer
+
 The left panel has three tabs:
 
 - **Files** - browse your repository's file tree, create and manage files and folders
@@ -27,6 +30,7 @@ In the Files tab, you can:
 Click any file to open it in the editor panel.
 
 ## Editing files
+
 The editor supports MDX files with full syntax highlighting. Changes you make are saved as **pending changes** - they aren't committed to your repository until you publish.
 
 <Callout type="note">
@@ -34,6 +38,7 @@ The editor supports MDX files with full syntax highlighting. Changes you make ar
 </Callout>
 
 ## Version history
+
 For any file, you can view its commit history to see how it has changed over time. This lets you:
 
 - See when changes were made and what the commit messages were
@@ -41,7 +46,9 @@ For any file, you can view its commit history to see how it has changed over tim
 - Compare past versions to understand what changed
 
 ## Binary files
+
 You can upload images and other binary assets (PNG, JPG, SVG, WOFF2, etc.) directly through the file explorer. These are stored temporarily in Doccupine's storage and committed to your repository when you publish.
 
 ## Read-only mode
+
 Team members with the **Viewer** or **Billing** role can browse files but cannot make edits. The editor will display content in read-only mode for these users.`;

--- a/src/templates/mdx/platform/fonts-settings.mdx.ts
+++ b/src/templates/mdx/platform/fonts-settings.mdx.ts
@@ -7,10 +7,13 @@ categoryOrder: 2
 order: 4
 section: "Platform"
 ---
+
 # Fonts Settings
+
 The Fonts settings page lets you customize your documentation site's typography using Google Fonts or locally uploaded font files.
 
 ## Google Fonts
+
 Select a font from the full Google Fonts library:
 
 1. Type a font name to search the library.
@@ -22,6 +25,7 @@ Select a font from the full Google Fonts library:
 </Callout>
 
 ## Local fonts
+
 Upload your own font files for complete typographic control:
 
 1. Click **Add Font Source** to add a font file entry.
@@ -32,6 +36,7 @@ Upload your own font files for complete typographic control:
 WOFF2 is recommended for the best compression and browser support.
 
 ## How it works
+
 Font settings are stored in \`fonts.json\` at the root of your repository. Here's an example using Google Fonts:
 
 \`\`\`json

--- a/src/templates/mdx/platform/index.mdx.ts
+++ b/src/templates/mdx/platform/index.mdx.ts
@@ -7,10 +7,13 @@ categoryOrder: 0
 order: 0
 section: "Platform"
 ---
+
 # Platform Overview
+
 The Doccupine platform gives you everything you need to create, customize, and host beautiful documentation websites - all from your browser. No local setup, no CI pipelines, no infrastructure to manage.
 
 ## What you get
+
 - **Browser-based editor** for writing and managing your documentation files
 - **One-click publishing** that commits to GitHub and deploys automatically
 - **Visual configuration** for themes, navigation, fonts, links, and more
@@ -19,6 +22,7 @@ The Doccupine platform gives you everything you need to create, customize, and h
 - **Team collaboration** with role-based access control
 
 ## How it works
+
 Doccupine connects two core pieces behind the scenes:
 
 1. **GitHub** stores your documentation source files in a Git repository
@@ -39,6 +43,7 @@ You write MDX files, configure your site through visual settings pages, and hit 
 </Callout>
 
 ## Dashboard
+
 After signing in, the dashboard shows all your projects. You'll see two sections:
 
 - **Your Projects** - documentation sites you own, plus a button to create new ones

--- a/src/templates/mdx/platform/navigation-settings.mdx.ts
+++ b/src/templates/mdx/platform/navigation-settings.mdx.ts
@@ -7,10 +7,13 @@ categoryOrder: 2
 order: 2
 section: "Platform"
 ---
+
 # Navigation Settings
+
 The Navigation Builder lets you define your sidebar structure through a visual, drag-and-drop interface. It lives inside the **File Explorer** as a dedicated **Navigation** tab, alongside the Files and Media tabs.
 
 ## Structure
+
 Navigation is organized into three levels:
 
 - **Section** - a top-level area of your site (e.g., "Docs", "API Reference"). Each section appears as a tab below the site header and has its own sidebar. Sections are defined by a label, URL slug, and docs directory.
@@ -18,27 +21,33 @@ Navigation is organized into three levels:
 - **Link** - an individual page entry within a category, defined by a slug and title
 
 ## Drag-and-drop reordering
+
 You can reorder items at every level by dragging their handles:
 
 - **Drag categories** between sections or within the same section to change their position
 - **Drag links** between categories or within the same category to reorder them
 
 ## Managing sections
+
 - Click **Add Section** in the toolbar to create a new section. Fill in the label, slug, and directory fields.
 - Click the **edit** button on a section header to open its edit modal, where you can update the label, slug, and directory.
 - Delete a section from its edit modal using the delete button. The root section cannot be deleted.
 
 ### The default section
+
 One section should have an empty slug (\`""\`). This is the default/root section that serves pages at the root URL. Pages not assigned to any other section belong here.
 
 ### Frontmatter-based sections
+
 You can also define sections purely through page frontmatter without using the Navigation Builder. Add a \`section\` field to your MDX frontmatter and Doccupine will create sections automatically. See the [Sections documentation](/sections) for details.
 
 ## Managing categories
+
 - Click **Add Category** within a section to create a new group
 - Click the **edit** button on a category to open its edit modal, where you can rename it or delete it
 
 ## Adding links
+
 Within each category, click **Add files** to open a popover that lists available MDX files not yet included in the navigation. You can:
 
 - **Search** by file name to filter the list
@@ -48,6 +57,7 @@ Within each category, click **Add files** to open a popover that lists available
 To remove a link, click the **delete** button next to it.
 
 ## Regenerate from files
+
 The toolbar includes a **Regenerate** button that rebuilds the entire navigation tree from your MDX files' frontmatter (\`category\`, \`categoryOrder\`, and \`order\` fields). A confirmation modal appears before any existing manual navigation is replaced.
 
 <Callout type="warning">
@@ -55,39 +65,45 @@ The toolbar includes a **Regenerate** button that rebuilds the entire navigation
 </Callout>
 
 ## Auto-generated vs. manual
+
 If you don't configure navigation at all, Doccupine automatically builds your sidebar from page frontmatter. The Navigation Builder is only needed when you want explicit control over the order and grouping.
 
 ## How it works
+
 When you save, the Navigation Builder writes two files to your repository as pending changes:
 
 - \`navigation.json\` - the category and link structure for each section
 - \`sections.json\` - the list of sections with their labels, slugs, and directories
 
 **Array format** for single-section sites (\`navigation.json\`):
+
 \`\`\`json
 [
   {
     "label": "Getting Started",
-    "links": [
-      { "slug": "getting-started", "title": "Quick Start" }
-    ]
+    "links": [{ "slug": "getting-started", "title": "Quick Start" }]
   }
 ]
 \`\`\`
 
 **Object format** for multi-section sites (\`navigation.json\`):
+
 \`\`\`json
 {
   "": [
     { "label": "General", "links": [{ "slug": "", "title": "Introduction" }] }
   ],
   "api": [
-    { "label": "Auth", "links": [{ "slug": "api/auth", "title": "Authentication" }] }
+    {
+      "label": "Auth",
+      "links": [{ "slug": "api/auth", "title": "Authentication" }]
+    }
   ]
 }
 \`\`\`
 
 **Sections** (\`sections.json\`):
+
 \`\`\`json
 [
   { "label": "Docs", "slug": "" },

--- a/src/templates/mdx/platform/project-settings.mdx.ts
+++ b/src/templates/mdx/platform/project-settings.mdx.ts
@@ -7,10 +7,13 @@ categoryOrder: 4
 order: 2
 section: "Platform"
 ---
+
 # Project Settings
+
 The Project settings page provides basic project management options including renaming and deletion.
 
 ## Renaming a project
+
 Enter a new name for your project and click **Save**. The project name is used in the dashboard and sidebar - it does not affect your site's URL or domain.
 
 ## Deleting a project
@@ -27,6 +30,7 @@ To delete a project:
 4. Click **Delete**.
 
 Deletion removes:
+
 - The GitHub repository (if managed by Doccupine)
 - The hosted deployment
 - All pending changes

--- a/src/templates/mdx/platform/publishing.mdx.ts
+++ b/src/templates/mdx/platform/publishing.mdx.ts
@@ -7,7 +7,9 @@ categoryOrder: 1
 order: 1
 section: "Platform"
 ---
+
 # Publishing Changes
+
 When you edit files in Doccupine, your changes are staged as pending. Nothing goes live until you explicitly publish.
 
 ## The publish workflow
@@ -19,6 +21,7 @@ When you edit files in Doccupine, your changes are staged as pending. Nothing go
 5. Click **Publish Changes**.
 
 Doccupine then:
+
 - Commits all pending changes to your GitHub repository
 - Triggers a new deployment
 - Clears all pending changes from the staging area
@@ -28,9 +31,11 @@ Doccupine then:
 </Callout>
 
 ## Discarding changes
+
 If you want to undo your pending edits, click **Discard All Changes** in the publish modal. This removes all staged changes without committing anything.
 
 ## File status badges
+
 In the publish modal, each file shows a badge indicating what changed:
 
 - **mod** - the file was modified
@@ -38,4 +43,5 @@ In the publish modal, each file shows a badge indicating what changed:
 - **bin** - the file is a binary asset (image, font, etc.)
 
 ## Auto-deploy from GitHub
+
 If you're using a user-connected GitHub repository and push changes directly (outside of Doccupine), the webhook triggers an automatic redeploy. This means you can use Doccupine's editor and Git-based workflows interchangeably.`;

--- a/src/templates/mdx/platform/site-settings.mdx.ts
+++ b/src/templates/mdx/platform/site-settings.mdx.ts
@@ -7,24 +7,31 @@ categoryOrder: 2
 order: 0
 section: "Platform"
 ---
+
 # Site Settings
+
 The Site settings page lets you configure the core metadata for your documentation site. These values are stored in \`config.json\` at the root of your repository.
 
 ## Fields
 
 ### Name
+
 The name of your documentation site. This appears in the site header and browser tab title.
 
 ### Description
+
 A short description of your documentation. Used in meta tags for search engine optimization and social media previews.
 
 ### Favicon
+
 Upload a favicon image that appears in browser tabs. Supported formats include PNG, ICO, and SVG. Use the file upload button to select an image from your computer.
 
 ### Preview image
+
 Upload an image used for social media and OpenGraph previews. This is the image that appears when your documentation URL is shared on platforms like Twitter, Slack, or Discord.
 
 ### Site URL
+
 The public URL of your deployed documentation site, such as \`https://docs.example.com\`. This value is used as the base URL when generating \`sitemap.xml\` and \`robots.txt\`, so search engines can discover and index your pages correctly. You can override this at deploy time by setting the \`NEXT_PUBLIC_SITE_URL\` environment variable.
 
 <Callout type="note">
@@ -32,6 +39,7 @@ The public URL of your deployed documentation site, such as \`https://docs.examp
 </Callout>
 
 ## How it works
+
 Behind the scenes, the Site settings page reads and writes \`config.json\` in your repository. You can also edit this file directly in the file editor if you prefer. See the [Globals](/globals) page for the full configuration reference.
 
 \`\`\`json

--- a/src/templates/mdx/platform/team-members.mdx.ts
+++ b/src/templates/mdx/platform/team-members.mdx.ts
@@ -7,10 +7,13 @@ categoryOrder: 4
 order: 0
 section: "Platform"
 ---
+
 # Team Members
+
 The Members settings page lets project owners invite collaborators and manage their access levels. Team members can view, edit, or manage billing depending on their assigned role.
 
 ## Inviting members
+
 1. Navigate to your project's **Members** settings.
 2. Enter the collaborator's email address.
 3. Select a role.
@@ -21,12 +24,15 @@ The invited user will see the project under **Shared Projects** on their dashboa
 ## Roles
 
 ### Viewer
+
 Can browse files and view the project, but cannot make edits or publish changes. Useful for stakeholders who need read access.
 
 ### Editor
+
 Can edit files and publish changes. Can also modify site configuration (theme, navigation, fonts, etc.). Cannot manage team members or billing.
 
 ### Billing
+
 Can access the billing management page and Stripe billing portal. Cannot edit files or site configuration.
 
 <Callout type="note">
@@ -34,6 +40,7 @@ Can access the billing management page and Stripe billing portal. Cannot edit fi
 </Callout>
 
 ## Member limits
+
 The number of team members depends on your plan:
 
 - **Pro** - up to 5 members
@@ -42,4 +49,5 @@ The number of team members depends on your plan:
 The Members page shows your current count against your plan's limit.
 
 ## Removing members
+
 Project owners can remove any member by clicking the remove button next to their name. Members can also remove themselves from a project by clicking **Leave Project**.`;

--- a/src/templates/mdx/platform/theme-settings.mdx.ts
+++ b/src/templates/mdx/platform/theme-settings.mdx.ts
@@ -7,10 +7,13 @@ categoryOrder: 2
 order: 1
 section: "Platform"
 ---
+
 # Theme Settings
+
 The Theme settings page gives you full control over your documentation site's visual appearance. Customize colors, upload logos, and configure separate light and dark mode palettes.
 
 ## Color palette
+
 The theme system uses an 18-color palette organized into groups:
 
 - **Primary** (light, base, dark) - your brand's main color, used for links, buttons, and accents
@@ -23,11 +26,13 @@ The theme system uses an 18-color palette organized into groups:
 Click any color swatch to open a color picker and adjust the value.
 
 ## Dark mode
+
 Enable the dark mode toggle to configure a separate palette for dark mode. When enabled, your site automatically switches based on the visitor's system preference.
 
 The dark mode palette uses the same 18-color structure, letting you fine-tune every color for both appearances.
 
 ## Logos
+
 Upload separate logo images for light and dark backgrounds:
 
 - **Light background logo** - shown when the site is in light mode
@@ -38,7 +43,9 @@ Upload separate logo images for light and dark backgrounds:
 </Callout>
 
 ## Reset to defaults
+
 Each palette section has a **Reset to defaults** button that restores the original Doccupine color values. This is useful if you want to start over after experimenting.
 
 ## How it works
+
 Theme settings are stored in \`theme.json\` at the root of your repository. Like all configuration, changes are staged as pending and go live when you publish.`;

--- a/src/templates/mdx/sections.mdx.ts
+++ b/src/templates/mdx/sections.mdx.ts
@@ -6,7 +6,9 @@ category: "Configuration"
 categoryOrder: 3
 order: 3
 ---
+
 # Sections
+
 Sections let you divide your documentation into separate top-level areas - for example "Guides", "API Reference", and "SDKs". Each section gets its own sidebar and appears as a horizontal tab bar below the site header.
 
 <Callout type="note">
@@ -14,9 +16,11 @@ Sections let you divide your documentation into separate top-level areas - for e
 </Callout>
 
 ## Automatic sections (frontmatter)
+
 The simplest way to add sections is through page frontmatter. Add a \`section\` field to group pages, and an optional \`sectionOrder\` to control the order of sections in the bar.
 
 ### Frontmatter fields
+
 - **section**: The display name for the section this page belongs to (e.g. "API Reference").
 - **sectionOrder**: Controls the position of the section in the bar. Lower numbers appear first.
 
@@ -32,6 +36,7 @@ sectionLabel: "Guides"
 \`\`\`
 
 ### Directory-based organization
+
 You can organize each section's files in a subdirectory that matches the section slug. When the directory name matches, Doccupine automatically assigns the files to that section and strips the directory from the URL.
 
 \`\`\`text
@@ -63,6 +68,7 @@ The directory \`platform/\` matches the section slug \`platform\`, so it is stri
 Files at the root level with a \`section\` field work too - they keep their full slug under the section prefix.
 
 ### Section index pages
+
 If a section has no index page (no file at its root URL), Doccupine generates a redirect to the first page in that section, sorted by \`categoryOrder\` then \`order\`.
 
 <Callout type="note">
@@ -70,6 +76,7 @@ If a section has no index page (no file at its root URL), Doccupine generates a 
 </Callout>
 
 ### Flat file example
+
 You can also keep all files at the root and rely purely on frontmatter:
 
 \`\`\`text
@@ -86,6 +93,7 @@ order: 1
 This page would be served at \`/api-reference/authentication\`.
 
 ## Explicit sections with sections.json
+
 For full control over slugs, create a \`sections.json\` file at your project root (the same folder where you run \`npx doccupine\`).
 
 ### Minimal example
@@ -98,6 +106,7 @@ For full control over slugs, create a \`sections.json\` file at your project roo
 \`\`\`
 
 This defines two sections. Pages are assigned automatically:
+
 - Files in a \`platform/\` directory belong to the "Platform" section (directory name matches slug).
 - Files with \`section: "Platform"\` in their frontmatter also belong to it.
 - Everything else stays in the root "Docs" section.
@@ -105,6 +114,7 @@ This defines two sections. Pages are assigned automatically:
 No \`directory\` field is needed when the directory name already matches the section slug.
 
 ### Example with explicit directories
+
 When the directory name differs from the slug, use the \`directory\` field to map them:
 
 \`\`\`json
@@ -116,11 +126,13 @@ When the directory name differs from the slug, use the \`directory\` field to ma
 \`\`\`
 
 ### Fields
+
 - **label**: The display name shown in the section bar.
 - **slug**: The URL prefix for this section. Use an empty string \`""\` for the default section that serves at the root.
 - **directory** (optional): The subdirectory under your watch directory that contains this section's MDX files. Only needed when the directory name differs from the slug.
 
 ### Directory structure example
+
 With the explicit directory config above and a watch directory of \`docs\`, your files would look like:
 
 \`\`\`text
@@ -137,6 +149,7 @@ docs/
 \`\`\`
 
 ## Section navigation
+
 Each section builds its own sidebar from the pages that belong to it. By default, pages are grouped by \`category\` and sorted by \`categoryOrder\` and \`order\` from frontmatter.
 
 For explicit control, use \`navigation.json\` with the object format to define per-section navigation:
@@ -144,7 +157,10 @@ For explicit control, use \`navigation.json\` with the object format to define p
 \`\`\`json
 {
   "": [
-    { "label": "General", "links": [{ "slug": "", "title": "Getting Started" }] }
+    {
+      "label": "General",
+      "links": [{ "slug": "", "title": "Getting Started" }]
+    }
   ],
   "platform": [
     { "label": "API", "links": [{ "slug": "platform/auth", "title": "Auth" }] }
@@ -155,6 +171,7 @@ For explicit control, use \`navigation.json\` with the object format to define p
 Keys are section slugs. The root section uses \`""\`. Sections without a key fall back to auto-generated navigation. See the Navigation page for the full format.
 
 ## How pages are assigned to sections
+
 Doccupine checks these rules in order and uses the first match:
 
 1. **Explicit directory** - the file is inside a directory listed in a section's \`directory\` field.
@@ -163,11 +180,13 @@ Doccupine checks these rules in order and uses the first match:
 4. **No match** - the page stays at the root.
 
 ## Precedence for section discovery
+
 1. **sections.json exists** - Doccupine uses it to define available sections.
 2. **No sections.json but pages have \`section\` frontmatter** - Doccupine auto-discovers sections from the frontmatter. Sections update live as you add or remove the \`section\` field from files.
 3. **Neither** - No section bar appears. The site works exactly as before.
 
 ## URL structure
+
 Pages in the default section (with \`slug: ""\`) serve at the root:
 
 - Default section: \`/getting-started\`, \`/installation\`
@@ -178,6 +197,7 @@ Pages in the default section (with \`slug: ""\`) serve at the root:
 </Callout>
 
 ## sections.json vs navigation.json
+
 These two config files serve different purposes and complement each other:
 
 - **sections.json** defines which sections exist - their labels, slugs, directory mappings, and order in the tab bar.
@@ -186,6 +206,7 @@ These two config files serve different purposes and complement each other:
 You can use either one independently. \`sections.json\` without \`navigation.json\` gives you sections with auto-generated sidebars. \`navigation.json\` without \`sections.json\` gives you custom sidebar ordering with frontmatter-discovered sections (or no sections at all).
 
 ## Tips
+
 - **Start simple**: Add \`section\` and \`sectionOrder\` to a few pages to try it out. No config files needed.
 - **Use directories**: Organize each section's files in a directory that matches the section slug for clean URLs and a tidy file tree.
 - **Rename the default tab**: Add \`sectionLabel: "Your Label"\` to your \`index.mdx\` frontmatter. Defaults to "Docs" if omitted.

--- a/src/templates/mdx/steps.mdx.ts
+++ b/src/templates/mdx/steps.mdx.ts
@@ -6,12 +6,15 @@ category: "Components"
 categoryOrder: 1
 order: 14
 ---
+
 # Steps
+
 Guide readers step-by-step using the Steps component.
 
 The Steps component is perfect for organizing procedures or workflows in a clear sequence. Include as many individual steps as necessary to outline your process.
 
 ## Steps Usage
+
 You can use the \`Steps\` component to create a step-by-step guide. Each step is represented by a \`Step\` component, which includes a title and content.
 
 \`\`\`mdx
@@ -20,9 +23,9 @@ You can use the \`Steps\` component to create a step-by-step guide. Each step is
     Lorem ipsum dolor sit amet, consectetur adipiscing elit.
   </Step>
 
-  <Step title="Step 2">
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-  </Step>
+<Step title="Step 2">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+</Step>
 
   <Step title="Step 3">
     Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -56,5 +59,4 @@ You can use the \`Steps\` component to create a step-by-step guide. Each step is
 
 <Field value="children" type="node" required>
   The content of the step.
-</Field>
-`;
+</Field>`;

--- a/src/templates/mdx/tabs.mdx.ts
+++ b/src/templates/mdx/tabs.mdx.ts
@@ -6,15 +6,18 @@ category: "Components"
 categoryOrder: 1
 order: 5
 ---
+
 # Tabs
+
 Use the Tabs component to display different content sections in a switchable panel layout.
 
 Tabs are useful for grouping related information while keeping the interface tidy. You can create as many tabs as needed, and each one can hold other components, text, or code snippets.
 
 ## Tabs Usage
+
 You can use the Tabs component directly within your MDX files without any import. The following example shows a basic usage:
 
-~~~mdx
+\`\`\`\`mdx
 <Tabs>
   <TabContent title="First tab">
     ☝️ This is the content shown only when the first tab is active.
@@ -27,6 +30,7 @@ You can use the Tabs component directly within your MDX files without any import
           }
       }
     \`\`\`
+
   </TabContent>
   <TabContent title="Second tab">
     ✌️ Content inside this second tab is separate from the first.
@@ -35,7 +39,7 @@ You can use the Tabs component directly within your MDX files without any import
     💪 This third tab contains its own unique content.
   </TabContent>
 </Tabs>
-~~~
+\`\`\`\`
 
 <Tabs>
   <TabContent title="First tab">
@@ -49,6 +53,7 @@ You can use the Tabs component directly within your MDX files without any import
         }
     }
     \`\`\`
+
   </TabContent>
   <TabContent title="Second tab">
     ✌️ Content inside this second tab is separate from the first.

--- a/src/templates/mdx/theme.mdx.ts
+++ b/src/templates/mdx/theme.mdx.ts
@@ -6,10 +6,13 @@ category: "Configuration"
 categoryOrder: 3
 order: 5
 ---
+
 # Theme
+
 Define your site’s color system with a \`theme.json\` file. This lets you tailor the look and feel of your documentation without changing content.
 
 ## theme.json
+
 Place a \`theme.json\` at your project root (the same folder where you execute \`npx doccupine\`). It supports multiple modes. Define a \`default\` mode and a \`dark\` mode.
 
 \`\`\`json
@@ -62,10 +65,12 @@ Place a \`theme.json\` at your project root (the same folder where you execute \
 \`\`\`
 
 ## Modes
+
 - **default**: The base color palette for your site.
 - **dark**: Dark‑mode palette.
 
 ## Fields
+
 - **primaryLight**: A lighter variant of your brand color, used for subtle accents and backgrounds.
 - **primary**: The main brand color.
 - **primaryDark**: A darker variant of your brand color for emphasis and hover states.
@@ -88,6 +93,7 @@ Place a \`theme.json\` at your project root (the same folder where you execute \
 - **logo.dark**: Path or URL to the logo used on dark backgrounds. Recommended size: 164×30 px.
 
 ## Behavior
+
 - **Placement**: Put \`theme.json\` in the project root alongside \`config.json\`.
 - **Partial palettes**: If a key is missing in a mode, consumers may fall back to the \`default\` value.
 - **Logo size**: Recommended dimensions are 164px width and 30px height.
@@ -97,11 +103,13 @@ Place a \`theme.json\` at your project root (the same folder where you execute \
 </Callout>
 
 ## Tips
+
 - **Contrast**: Ensure sufficient contrast between text and backgrounds for readability.
 - **Branding**: Start with your brand’s \`primary\` color, then derive \`primaryLight\` and \`primaryDark\`.
 - **Iterate**: Adjust colors and refresh the site to preview changes quickly.
 
 # Demo
+
 In the following demos, you can see how the theme can be changed. To override the theme, create a \`theme.json\` file in the project root and copy paste the code below.
 
 <DemoTheme variant="purple" />
@@ -155,6 +163,7 @@ In the following demos, you can see how the theme can be changed. To override th
   }
 }
 \`\`\`
+
 <DemoTheme variant="purple" />
 
 ## Green
@@ -203,6 +212,7 @@ In the following demos, you can see how the theme can be changed. To override th
   }
 }
 \`\`\`
+
 <DemoTheme variant="green" />
 
 ## Yellow

--- a/src/templates/mdx/update.mdx.ts
+++ b/src/templates/mdx/update.mdx.ts
@@ -6,7 +6,9 @@ category: "Components"
 categoryOrder: 1
 order: 12
 ---
+
 # Update
+
 Easily manage and present change history.
 
 The \`Update\` component helps you display release notes, version details, and changelogs in a standardized format.
@@ -14,34 +16,35 @@ The \`Update\` component helps you display release notes, version details, and c
 <Update label="Example" description="v0.0.1">
   ## Example entry
 
-  You can include anything here—images, code snippets, or a bullet list of modifications.
+You can include anything here—images, code snippets, or a bullet list of modifications.
 
-  ![Demo Image](https://docs.doccupine.com/demo.png)
+![Demo Image](https://docs.doccupine.com/demo.png)
 
-  ### Key additions
+### Key additions
 
-  - Fully responsive layout
-  - Individual anchor for each update
-  - Automatic RSS feed entry generation
-</Update>
+- Fully responsive layout
+- Individual anchor for each update
+- Automatic RSS feed entry generation
+  </Update>
 
 ## Update Usage
+
 You can combine multiple \`Update\` components to build complete changelogs.
 
 \`\`\`mdx
 <Update label="Example" description="v0.0.1">
   ## Example entry
 
-  You can include anything here—images, code snippets, or a bullet list of modifications.
+You can include anything here—images, code snippets, or a bullet list of modifications.
 
-  ![Demo Image](https://docs.doccupine.com/demo.png)
+![Demo Image](https://docs.doccupine.com/demo.png)
 
-  ### Key additions
+### Key additions
 
-  - Fully responsive layout
-  - Individual anchor for each update
-  - Automatic RSS feed entry generation
-</Update>
+- Fully responsive layout
+- Individual anchor for each update
+- Automatic RSS feed entry generation
+  </Update>
 \`\`\`
 
 ## Properties

--- a/src/templates/package.ts
+++ b/src/templates/package.ts
@@ -41,7 +41,7 @@ export const packageJsonTemplate =
         "@types/node": "^25",
         "@types/react": "^19",
         "@types/react-dom": "^19",
-        "baseline-browser-mapping": "^2.10.27",
+        "baseline-browser-mapping": "^2.10.28",
         eslint: "^9",
         "eslint-config-next": "16.2.6",
         prettier: "^3.8.3",

--- a/src/templates/pnpmWorkspace.ts
+++ b/src/templates/pnpmWorkspace.ts
@@ -1,0 +1,7 @@
+export const pnpmWorkspaceTemplate = `allowBuilds:
+  core-js: false
+  esbuild: false
+  protobufjs: false
+  sharp: false
+  unrs-resolver: false
+`;

--- a/src/templates/prettierignore.ts
+++ b/src/templates/prettierignore.ts
@@ -4,4 +4,8 @@ package.json
 package-lock.json
 pnpm-lock.yaml
 pnpm-workspace.yaml
+public/llms.txt
+public/llms-full.txt
+public/**/*.md
+.doccupine-llms-manifest.json
 `;

--- a/src/templates/prettierignore.ts
+++ b/src/templates/prettierignore.ts
@@ -4,8 +4,4 @@ package.json
 package-lock.json
 pnpm-lock.yaml
 pnpm-workspace.yaml
-public/llms.txt
-public/llms-full.txt
-public/**/*.md
-.doccupine-llms-manifest.json
 `;


### PR DESCRIPTION
## Summary
- Adds support for the [llms.txt standard](https://llmstxt.org/) by emitting three artifacts into the generated Next.js app's `public/` dir on every build / watch update
- `public/llms.txt` is a curated markdown index of all docs pages, grouped by `## Section` and `### Category`, sorted by `categoryOrder` then `order`
- `public/llms-full.txt` concatenates every page's raw MDX (JSX preserved) for one-shot LLM ingestion
- `public/<slug>.md` per-page raw markdown so agents can fetch a single page without parsing the React app
- Mirrors the existing sitemap / robots pattern; regenerates on initial build, MDX add/change/delete, and `config.json` changes; falls back to relative URLs when no site URL is configured
- Stale per-page `.md` files are cleaned up across runs via a small `.doccupine-llms-manifest.json` written to the output dir