### PR TITLE
feat(templates): navigation & tab icons, nested nav, and unique heading anchors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -908,6 +908,13 @@ class MDXToNextJSGenerator {
       categoryOrder: frontmatter.categoryOrder || 0,
       order: frontmatter.order || 0,
       section: sectionSlug,
+      // Sidebar icons (Lucide names). Kept separate from `icon`, which is
+      // reserved for the favicon/OG metadata. Only emitted when set so the
+      // generated page literal stays lean.
+      ...(frontmatter.navIcon ? { navIcon: String(frontmatter.navIcon) } : {}),
+      ...(frontmatter.categoryIcon
+        ? { categoryIcon: String(frontmatter.categoryIcon) }
+        : {}),
       lastModified,
     };
   }

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -315,6 +315,7 @@ ${
       date: "2025-01-15",
       category: "Introduction",
       categoryOrder: 0,
+      categoryIcon: "rocket",
       order: 0,
     },
   ];

--- a/src/lib/structures.ts
+++ b/src/lib/structures.ts
@@ -48,6 +48,7 @@ import { iconTemplate } from "../templates/components/layout/Icon.js";
 import { pictogramsTemplate } from "../templates/components/layout/Pictograms.js";
 import { sharedStyledTemplate } from "../templates/components/layout/SharedStyles.js";
 import { siteGateComponentTemplate } from "../templates/components/layout/SiteGate.js";
+import { slugTemplate } from "../templates/components/layout/Slug.js";
 import { staticLinksTemplate } from "../templates/components/layout/StaticLinks.js";
 import { stepsTemplate } from "../templates/components/layout/Steps.js";
 import { tabsTemplate } from "../templates/components/layout/Tabs.js";
@@ -193,6 +194,7 @@ export const appStructure: Record<string, string> = {
   "components/layout/Pictograms.tsx": pictogramsTemplate,
   "components/layout/SharedStyled.ts": sharedStyledTemplate,
   "components/layout/SiteGate.tsx": siteGateComponentTemplate,
+  "components/layout/Slug.ts": slugTemplate,
   "components/layout/StaticLinks.tsx": staticLinksTemplate,
   "components/layout/Steps.tsx": stepsTemplate,
   "components/layout/Tabs.tsx": tabsTemplate,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,6 +15,8 @@ export interface PageMeta {
   categoryOrder: number;
   order: number;
   section: string;
+  navIcon?: string;
+  categoryIcon?: string;
   lastModified?: string;
 }
 

--- a/src/templates/components/Docs.ts
+++ b/src/templates/components/Docs.ts
@@ -10,6 +10,7 @@ import remarkGfm from "remark-gfm";
 import { useMDXComponents } from "@/components/MDXComponents";
 import { DocsSideBar } from "@/components/DocsSideBar";
 import { ActionBar } from "@/components/layout/ActionBar";
+import { createSlugger } from "@/components/layout/Slug";
 
 interface DocsProps {
   content: string;
@@ -21,17 +22,9 @@ interface Heading {
   level: number;
 }
 
-function generateId(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^\\w\\s-]/g, "")
-    .replace(/\\s+/g, "-")
-    .trim();
-}
-
 function extractHeadings(content: string): Heading[] {
   const contentWithoutCodeBlocks = content.replace(/\`\`\`[\\s\\S]*?\`\`\`/g, "");
-  const headings: (Heading & { position: number })[] = [];
+  const entries: { text: string; level: number; position: number }[] = [];
   let match;
 
   // Markdown headings (# .. ######)
@@ -39,24 +32,22 @@ function extractHeadings(content: string): Heading[] {
   while ((match = headingRegex.exec(contentWithoutCodeBlocks)) !== null) {
     const level = match[1].length;
     const text = match[2].trim();
-    headings.push({ id: generateId(text), text, level, position: match.index });
+    entries.push({ text, level, position: match.index });
   }
 
   // <Update label="..."> blocks surface their label as a top-level entry
   const updateRegex = /<Update\\b[^>]*?\\blabel=["']([^"']+)["'][^>]*>/g;
   while ((match = updateRegex.exec(contentWithoutCodeBlocks)) !== null) {
-    const text = match[1].trim();
-    headings.push({
-      id: generateId(text),
-      text,
-      level: 1,
-      position: match.index,
-    });
+    entries.push({ text: match[1].trim(), level: 1, position: match.index });
   }
 
-  return headings
+  // Assign ids in document order with a shared slugger so repeated heading
+  // text produces unique anchors ("setup", "setup-1", ...) that stay in sync
+  // with the ids rendered by MDXComponents/Update.
+  const slug = createSlugger();
+  return entries
     .sort((a, b) => a.position - b.position)
-    .map(({ id, text, level }) => ({ id, text, level }));
+    .map(({ text, level }) => ({ id: slug(text), text, level }));
 }
 
 function extractComponentNames(source: string): string[] {

--- a/src/templates/components/MDXComponents.ts
+++ b/src/templates/components/MDXComponents.ts
@@ -17,6 +17,7 @@ import { Steps, Step } from "@/components/layout/Steps";
 import { Button } from "@/components/layout/Button";
 import { ColorSwatch, ColorSwatchGroup } from "@/components/layout/ColorSwatch";
 import { DemoTheme } from "@/components/layout/DemoTheme";
+import { createSlugger } from "@/components/layout/Slug";
 
 interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
   children?: React.ReactNode;
@@ -40,14 +41,6 @@ function extractAllTextFromChildren(children: React.ReactNode): string {
     return extractAllTextFromChildren(element.props.children);
   }
   return "";
-}
-
-function generateId(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^\\w\\s-]/g, "")
-    .replace(/\\s+/g, "-")
-    .trim();
 }
 
 // Map <pre><code class="language-xyz"> to our <Code /> component
@@ -74,10 +67,14 @@ function Pre(props: PreProps) {
 }
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
+  // One slugger per render so repeated heading text (and <Update> labels)
+  // resolve to unique, document-order ids that match the index sidebar built
+  // in components/Docs.tsx.
+  const slug = createSlugger();
   return {
     // Headings with auto-generated ids for TOC and deep links
     h1: ({ children, ...props }: HeadingProps) => {
-      const id = generateId(extractAllTextFromChildren(children));
+      const id = slug(extractAllTextFromChildren(children));
       return (
         <h1 id={id} {...props}>
           {children}
@@ -85,7 +82,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
       );
     },
     h2: ({ children, ...props }: HeadingProps) => {
-      const id = generateId(extractAllTextFromChildren(children));
+      const id = slug(extractAllTextFromChildren(children));
       return (
         <h2 id={id} {...props}>
           {children}
@@ -93,7 +90,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
       );
     },
     h3: ({ children, ...props }: HeadingProps) => {
-      const id = generateId(extractAllTextFromChildren(children));
+      const id = slug(extractAllTextFromChildren(children));
       return (
         <h3 id={id} {...props}>
           {children}
@@ -101,7 +98,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
       );
     },
     h4: ({ children, ...props }: HeadingProps) => {
-      const id = generateId(extractAllTextFromChildren(children));
+      const id = slug(extractAllTextFromChildren(children));
       return (
         <h4 id={id} {...props}>
           {children}
@@ -109,7 +106,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
       );
     },
     h5: ({ children, ...props }: HeadingProps) => {
-      const id = generateId(extractAllTextFromChildren(children));
+      const id = slug(extractAllTextFromChildren(children));
       return (
         <h5 id={id} {...props}>
           {children}
@@ -117,7 +114,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
       );
     },
     h6: ({ children, ...props }: HeadingProps) => {
-      const id = generateId(extractAllTextFromChildren(children));
+      const id = slug(extractAllTextFromChildren(children));
       return (
         <h6 id={id} {...props}>
           {children}
@@ -166,7 +163,11 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     Icon,
     Columns,
     Field,
-    Update,
+    // Share the heading slugger so an <Update> label anchor stays unique and
+    // in document order alongside the surrounding headings.
+    Update: (props: React.ComponentProps<typeof Update>) => (
+      <Update {...props} id={slug(props.label)} />
+    ),
     Steps,
     Step,
     Button,

--- a/src/templates/components/SectionNavProvider.ts
+++ b/src/templates/components/SectionNavProvider.ts
@@ -15,7 +15,13 @@ import {
 import rawNavigation from "@/navigation.json";
 
 // navigation.json can be an array (root section only) or an object keyed by section slug
-type NavItem = { label: string; links: { slug: string; title: string }[] };
+type NavLink = {
+  slug?: string;
+  title: string;
+  icon?: string;
+  links?: NavLink[];
+};
+type NavItem = { label: string; icon?: string; links: NavLink[] };
 type NavigationConfig = NavItem[] | Record<string, NavItem[]>;
 
 const navigation = rawNavigation as NavigationConfig;
@@ -83,6 +89,7 @@ function SectionNavProvider({
       date: "2025-01-15",
       category: "Introduction",
       categoryOrder: 0,
+      categoryIcon: "rocket",
       order: 0,
     },
   ];

--- a/src/templates/components/SideBar.ts
+++ b/src/templates/components/SideBar.ts
@@ -10,24 +10,142 @@ import {
   StyledSidebarListItem,
   StyledStrong,
   StyledSidebarListItemLink,
+  StyledSidebarGroupButton,
+  StyledSidebarGroupRow,
+  StyledSidebarGroupLink,
+  StyledSidebarGroupChevron,
+  StyledSidebarGroupContent,
   StyledSidebarFooter,
   StyleMobileBar,
   StyledMobileBurger,
 } from "@/components/layout/DocsComponents";
+import { Icon } from "@/components/layout/Icon";
 import { useLockBodyScroll } from "@/components/LockBodyScroll";
+
+// A link can be a leaf (slug + title) or a group with nested children. Both the
+// category icon and the per-link icon are optional Lucide names.
+type NavItemLink = {
+  slug?: string;
+  title: string;
+  icon?: string;
+  links?: NavItemLink[];
+};
 
 type NavItem = {
   label: string;
+  icon?: string;
   links: NavItemLink[];
-};
-
-type NavItemLink = {
-  slug: string;
-  title: string;
 };
 
 interface SideBarProps {
   result: NavItem[];
+}
+
+function linkContainsActivePath(link: NavItemLink, pathname: string): boolean {
+  if (link.slug !== undefined && pathname === \`/\${link.slug}\`) {
+    return true;
+  }
+  return (link.links ?? []).some((child) =>
+    linkContainsActivePath(child, pathname),
+  );
+}
+
+function SidebarNavLink({
+  link,
+  depth,
+  pathname,
+  onNavigate,
+}: {
+  link: NavItemLink;
+  depth: number;
+  pathname: string;
+  onNavigate: () => void;
+}) {
+  const children = link.links ?? [];
+  const hasChildren = children.length > 0;
+  const href = link.slug !== undefined ? \`/\${link.slug}\` : undefined;
+  const isActive = href !== undefined && pathname === href;
+  const indent = { paddingLeft: \`\${20 + depth * 14}px\` };
+
+  // Open collapsible groups that contain the active page so deep links land
+  // with their ancestors already expanded.
+  const [isOpen, setIsOpen] = useState(
+    hasChildren
+      ? children.some((child) => linkContainsActivePath(child, pathname))
+      : false,
+  );
+
+  if (!hasChildren) {
+    return (
+      <StyledSidebarListItem>
+        <StyledSidebarListItemLink
+          href={href ?? "#"}
+          $isActive={isActive}
+          onClick={onNavigate}
+          style={indent}
+        >
+          {link.icon && <Icon name={link.icon} size={16} />}
+          {link.title}
+        </StyledSidebarListItemLink>
+      </StyledSidebarListItem>
+    );
+  }
+
+  const toggle = () => setIsOpen((prev) => !prev);
+  const toggleLabel = isOpen
+    ? \`Collapse \${link.title}\`
+    : \`Expand \${link.title}\`;
+  const groupActive = linkContainsActivePath(link, pathname);
+
+  return (
+    <li>
+      {href !== undefined ? (
+        <StyledSidebarGroupRow
+          $isActive={groupActive}
+          $isOpen={isOpen}
+          style={indent}
+        >
+          <StyledSidebarGroupLink href={href} onClick={onNavigate}>
+            {link.icon && <Icon name={link.icon} size={16} />}
+            {link.title}
+          </StyledSidebarGroupLink>
+          <StyledSidebarGroupChevron
+            type="button"
+            onClick={toggle}
+            aria-expanded={isOpen}
+            aria-label={toggleLabel}
+          >
+            <Icon name="chevron-right" size={16} />
+          </StyledSidebarGroupChevron>
+        </StyledSidebarGroupRow>
+      ) : (
+        <StyledSidebarGroupButton
+          type="button"
+          onClick={toggle}
+          $isActive={groupActive}
+          $isOpen={isOpen}
+          style={indent}
+          aria-expanded={isOpen}
+          aria-label={toggleLabel}
+        >
+          {link.icon && <Icon name={link.icon} size={16} />}
+          {link.title}
+          <Icon name="chevron-right" size={16} />
+        </StyledSidebarGroupButton>
+      )}
+      <StyledSidebarGroupContent $isOpen={isOpen}>
+        {children.map((child: NavItemLink, index: number) => (
+          <SidebarNavLink
+            key={index}
+            link={child}
+            depth={depth + 1}
+            pathname={pathname}
+            onNavigate={onNavigate}
+          />
+        ))}
+      </StyledSidebarGroupContent>
+    </li>
+  );
 }
 
 function SideBar({ result }: SideBarProps) {
@@ -59,25 +177,24 @@ function SideBar({ result }: SideBarProps) {
             return (
               <StyledSidebarList key={index}>
                 <StyledSidebarListItem>
-                  <StyledStrong>{item.label}</StyledStrong>{" "}
+                  <StyledStrong>
+                    {item.icon && <Icon name={item.icon} size={16} />}
+                    {item.label}
+                  </StyledStrong>{" "}
                 </StyledSidebarListItem>
                 <li>
                   <Space $size={20} />
                 </li>
                 {item.links &&
-                  item.links.map((link: NavItemLink, indexChild: number) => {
-                    return (
-                      <StyledSidebarListItem key={indexChild}>
-                        <StyledSidebarListItemLink
-                          href={\`/\${link.slug}\`}
-                          $isActive={pathname === \`/\${link.slug}\`}
-                          onClick={() => setIsMobileMenuOpen(false)}
-                        >
-                          {link.title}
-                        </StyledSidebarListItemLink>
-                      </StyledSidebarListItem>
-                    );
-                  })}
+                  item.links.map((link: NavItemLink, indexChild: number) => (
+                    <SidebarNavLink
+                      key={indexChild}
+                      link={link}
+                      depth={0}
+                      pathname={pathname}
+                      onNavigate={() => setIsMobileMenuOpen(false)}
+                    />
+                  ))}
                 <li aria-hidden="true">
                   <Space $size={20} />
                 </li>

--- a/src/templates/components/layout/DocsComponents.ts
+++ b/src/templates/components/layout/DocsComponents.ts
@@ -115,6 +115,7 @@ export const StyledMarkdownContainer = styled.div\`
 interface Props {
   theme?: Theme;
   $isActive?: boolean;
+  $isOpen?: boolean;
   $hasSectionBar?: boolean;
 }
 
@@ -272,6 +273,13 @@ export const StyledStrong = styled.strong<{ theme: Theme }>\`
   font-weight: 600;
   \${({ theme }) => styledStrong(theme)};
   color: \${({ theme }) => theme.colors.accentStrong};
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+
+  & svg {
+    flex-shrink: 0;
+  }
 \`;
 
 export const StyledSidebarListItem = styled.li\`
@@ -280,15 +288,25 @@ export const StyledSidebarListItem = styled.li\`
   clear: both;
 \`;
 
-export const StyledSidebarListItemLink = styled(Link)<Props>\`
+// Shared appearance for every sidebar row - leaf links AND nested group
+// headers - so hover, active state, and the left rail read identically.
+const sidebarRowStyles = css<Props>\`
   text-decoration: none;
   font-size: \${({ theme }) => theme.fontSizes.small.lg};
   line-height: 1.6;
   color: \${({ theme }) => theme.colors.accentMuted};
   padding: 5px 0 5px 20px;
   display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
   transition: all 0.3s ease;
   border-left: solid 1px \${({ theme }) => theme.colors.grayLight};
+
+  & svg {
+    flex-shrink: 0;
+  }
 
   &:hover {
     color: \${({ theme }) => theme.colors.accent};
@@ -297,11 +315,89 @@ export const StyledSidebarListItemLink = styled(Link)<Props>\`
 
   \${({ $isActive, theme }) =>
     $isActive &&
-    \`
-			color: \${theme.colors.accentStrong};
-			border-color: \${theme.colors.primary};
-			font-weight: 600;
-	\`};
+    css\`
+      color: \${theme.colors.accentStrong};
+      border-color: \${theme.colors.primary};
+      font-weight: 600;
+    \`};
+\`;
+
+// The collapse chevron points right when closed and rotates to point down
+// when the group is open.
+const sidebarChevron = css<Props>\`
+  & .lucide-chevron-right {
+    margin-left: auto;
+    transition: transform 0.3s ease;
+
+    \${({ $isOpen }) =>
+      $isOpen &&
+      css\`
+        transform: rotate(90deg);
+      \`}
+  }
+\`;
+
+export const StyledSidebarListItemLink = styled(Link)<Props>\`
+  \${sidebarRowStyles};
+\`;
+
+// Nested navigation group. The header shares the link appearance/hover; a
+// non-navigable group is a single toggle button, while a group that is also a
+// page pairs a link with a chevron toggle. Children live in
+// StyledSidebarGroupContent, which animates open/closed via height 0 <-> auto
+// (enabled by interpolate-size in GlobalStyles, same as the Accordion).
+export const StyledSidebarGroupButton = styled.button<Props>\`
+  \${resetButton};
+  \${sidebarRowStyles};
+  \${sidebarChevron};
+  width: 100%;
+  text-align: left;
+\`;
+
+export const StyledSidebarGroupRow = styled.div<Props>\`
+  \${sidebarRowStyles};
+  \${sidebarChevron};
+\`;
+
+export const StyledSidebarGroupLink = styled(Link)\`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+  color: inherit;
+  text-decoration: none;
+
+  & svg {
+    flex-shrink: 0;
+  }
+\`;
+
+export const StyledSidebarGroupChevron = styled.button\`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  cursor: pointer;
+\`;
+
+export const StyledSidebarGroupContent = styled.ul<Props>\`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  height: 0;
+  overflow: clip;
+  transition: all 0.3s ease;
+
+  \${({ $isOpen }) =>
+    $isOpen &&
+    css\`
+      height: auto;
+    \`}
 \`;
 
 export const StyleMobileBar = styled.button<Props>\`

--- a/src/templates/components/layout/DocsNavigation.ts
+++ b/src/templates/components/layout/DocsNavigation.ts
@@ -87,9 +87,13 @@ const StyledSpacer = styled.div\`
 \`;
 
 interface Page {
-  slug: string;
+  // Optional: nested group nodes may act as headers without their own page.
+  // collectPages() only pushes nodes that actually have a slug.
+  slug?: string;
   title: string;
   category?: string;
+  links?: Page[];
+  items?: Page[];
   [key: string]: unknown;
 }
 
@@ -109,18 +113,29 @@ interface DocsNavigationProps {
 function DocsNavigation({ result }: DocsNavigationProps) {
   const { isOpen } = useContext(ChatContext);
   const pathname = usePathname();
-  const allPages: Page[] = result.flatMap((item) => {
-    if (item.links && Array.isArray(item.links)) {
-      return item.links;
+  // Walk categories and any nested link groups depth-first so prev/next spans
+  // every real page (a node with a slug), in reading order.
+  const collectPages = (nodes: unknown): Page[] => {
+    if (!Array.isArray(nodes)) return [];
+    const pages: Page[] = [];
+    for (const node of nodes as Page[]) {
+      if (node && node.slug !== undefined) {
+        pages.push(node);
+      }
+      const children = node && ((node.links ?? node.items) as unknown);
+      if (Array.isArray(children)) {
+        pages.push(...collectPages(children));
+      }
     }
-    if (item.items && Array.isArray(item.items)) {
-      return item.items;
-    }
-    if (item.slug !== undefined) {
-      return [item as Page];
-    }
-    return [];
-  });
+    return pages;
+  };
+  const allPages: Page[] = result.flatMap((item) =>
+    collectPages(
+      item.links ??
+        item.items ??
+        (item.slug !== undefined ? [item as Page] : []),
+    ),
+  );
   const currentSlug = pathname.replace(/^\\//, "").replace(/\\/$/, "");
   const currentIndex = allPages.findIndex((page) => page.slug === currentSlug);
   const prevPage = currentIndex > 0 ? allPages[currentIndex - 1] : null;

--- a/src/templates/components/layout/Slug.ts
+++ b/src/templates/components/layout/Slug.ts
@@ -1,0 +1,32 @@
+export const slugTemplate = `// Shared heading/anchor id helpers.
+//
+// \`slugify\` turns heading text into a URL-safe base slug. \`createSlugger\`
+// wraps it with occurrence-based de-duplication so repeated heading text
+// yields stable, unique ids ("setup", "setup-1", "setup-2", ...) matching
+// the scheme used by GitHub and rehype-slug.
+//
+// The index sidebar (components/Docs.tsx) and the rendered headings
+// (components/MDXComponents.tsx, components/layout/Update.tsx) must walk the
+// document in the same order with a shared slugger so every sidebar link
+// resolves to exactly one heading.
+
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\\w\\s-]/g, "")
+    .replace(/\\s+/g, "-")
+    .trim();
+}
+
+export type Slugger = (text: string) => string;
+
+export function createSlugger(): Slugger {
+  const seen = new Map<string, number>();
+  return (text: string) => {
+    const base = slugify(text);
+    const count = seen.get(base) ?? 0;
+    seen.set(base, count + 1);
+    return count === 0 ? base : \`\${base}-\${count}\`;
+  };
+}
+`;

--- a/src/templates/components/layout/Tabs.ts
+++ b/src/templates/components/layout/Tabs.ts
@@ -4,8 +4,10 @@ import { styledText } from "cherry-styled-components";
 import React, { useState, ReactNode } from "react";
 import styled, { css } from "styled-components";
 import { thinScrollbar } from "@/components/layout/SharedStyled";
+import { Icon } from "@/components/layout/Icon";
 interface TabContentProps {
   title: string;
+  icon?: string;
   children: ReactNode;
 }
 interface TabsProps {
@@ -28,6 +30,10 @@ const TabsList = styled.div<{ theme: Theme }>\`
 \`;
 const TabButton = styled.button<{ theme: Theme; $isActive?: boolean }>\`
   flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
   padding: 12px 20px;
   border: none;
   background: \${({ theme }) => theme.colors.light};
@@ -38,6 +44,10 @@ const TabButton = styled.button<{ theme: Theme; $isActive?: boolean }>\`
   \${({ theme }) => styledText(theme)};
   color: \${({ theme }) => theme.colors.dark};
   font-weight: 600;
+
+  & svg {
+    flex-shrink: 0;
+  }
   \${({ theme, $isActive }) =>
     $isActive &&
     css\`
@@ -105,6 +115,7 @@ const Tabs: React.FC<TabsProps> = ({ children }) => {
             onClick={() => setActiveTab(index)}
             type="button"
           >
+            {tab.props.icon && <Icon name={tab.props.icon} size={18} />}
             {tab.props.title}
           </TabButton>
         ))}

--- a/src/templates/components/layout/Update.ts
+++ b/src/templates/components/layout/Update.ts
@@ -2,6 +2,7 @@ export const updateTemplate = `"use client";
 import styled from "styled-components";
 import { styledSmall } from "cherry-styled-components";
 import { mq, Theme } from "@/app/theme";
+import { slugify } from "@/components/layout/Slug";
 
 const StyledUpdate = styled.div<{ theme: Theme; $columns?: number }>\`
   position: relative;
@@ -15,14 +16,22 @@ const StyledUpdate = styled.div<{ theme: Theme; $columns?: number }>\`
   }
 \`;
 
-const StyledUpdateLabel = styled.span<{ theme: Theme }>\`
+const StyledUpdateLabel = styled.a<{ theme: Theme }>\`
+  display: inline-block;
+  width: fit-content;
   background: \${({ theme }) =>
     \`color-mix(in srgb, \${theme.colors.primaryLight} 20%, transparent)\`};
   color: \${({ theme }) => theme.colors.primary};
   padding: 2px 4px;
   border-radius: \${({ theme }) => theme.spacing.radius.xs};
   font-weight: 600;
+  text-decoration: none;
   \${({ theme }) => styledSmall(theme)};
+
+  &:hover {
+    background: \${({ theme }) =>
+      \`color-mix(in srgb, \${theme.colors.primaryLight} 35%, transparent)\`};
+  }
 \`;
 
 const StyledUpdateDescription = styled.div<{ theme: Theme }>\`
@@ -53,22 +62,18 @@ interface UpdateProps extends React.HTMLAttributes<HTMLDivElement> {
   description: string;
 }
 
-// Keep in sync with generateId in components/Docs.ts so the index sidebar
-// anchor (#id) resolves to this block.
-function generateId(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^\\w\\s-]/g, "")
-    .replace(/\\s+/g, "-")
-    .trim();
-}
-
-function Update({ children, label, description }: UpdateProps) {
+function Update({ children, label, description, id }: UpdateProps) {
+  // MDXComponents injects a de-duplicated id from the shared slugger so the
+  // index sidebar anchor resolves here; fall back to a plain slug when used
+  // outside the MDX pipeline. The label doubles as an anchor so readers can
+  // right-click to copy the deep link (native #anchor jump is offset by the
+  // global scroll-padding-top).
+  const anchor = id ?? slugify(label);
   return (
-    <StyledUpdate id={generateId(label)}>
+    <StyledUpdate id={anchor}>
       <StyledUpdateSidebar>
         <div>
-          <StyledUpdateLabel>{label}</StyledUpdateLabel>
+          <StyledUpdateLabel href={\`#\${anchor}\`}>{label}</StyledUpdateLabel>
         </div>
         <StyledUpdateDescription>{description}</StyledUpdateDescription>
       </StyledUpdateSidebar>

--- a/src/templates/mdx/components.mdx.ts
+++ b/src/templates/mdx/components.mdx.ts
@@ -4,6 +4,7 @@ description: "Explore the full library of built-in components available in your 
 date: "2026-02-19"
 category: "Components"
 categoryOrder: 1
+categoryIcon: "blocks"
 order: 0
 ---
 

--- a/src/templates/mdx/globals.mdx.ts
+++ b/src/templates/mdx/globals.mdx.ts
@@ -10,6 +10,7 @@ description: "Configure global settings for your documentation."
 date: "2026-02-19"
 category: "Configuration"
 categoryOrder: 3
+categoryIcon: "settings"
 order: 1
 ---
 

--- a/src/templates/mdx/index.mdx.ts
+++ b/src/templates/mdx/index.mdx.ts
@@ -6,6 +6,7 @@ description: "${DEFAULT_DESCRIPTION}"
 date: "2026-02-19"
 category: "Getting Started"
 categoryOrder: 0
+categoryIcon: "rocket"
 order: 0
 ---
 

--- a/src/templates/mdx/navigation.mdx.ts
+++ b/src/templates/mdx/navigation.mdx.ts
@@ -20,6 +20,8 @@ When no custom navigation is provided, Doccupine generates a structure based on 
 - **category**: The category name that groups the page in the sidebar.
 - **categoryOrder**: The position of the category within the sidebar. Lower numbers appear first.
 - **order**: The position of the page within its category. Lower numbers appear first.
+- **navIcon**: Optional [Lucide](https://lucide.dev/icons) icon name shown next to the page's sidebar link.
+- **categoryIcon**: Optional Lucide icon name for the page's category header. The first page in a category that sets it wins.
 
 ### Example frontmatter
 
@@ -87,7 +89,8 @@ The simplest format is an array of categories. When using [sections](/sections),
       { "slug": "ai-assistant", "title": "AI Assistant" },
       { "slug": "model-context-protocol", "title": "Model Context Protocol" },
       { "slug": "analytics", "title": "Analytics" },
-      { "slug": "deployment-and-hosting", "title": "Deployment & Hosting" }
+      { "slug": "deployment-and-hosting", "title": "Deployment & Hosting" },
+      { "slug": "authentication", "title": "Authentication" }
     ]
   }
 ]
@@ -125,9 +128,74 @@ The key \`""\` controls the root section. Other keys match section slugs defined
 ### Fields
 
 - **label**: The section header shown in the sidebar.
+- **icon**: Optional [Lucide](https://lucide.dev/icons) icon name shown next to the category header.
 - **links**: An array of page entries for that section.
   - **slug**: The MDX file slug (filename without extension). Use an empty string \`""\` for \`index.mdx\`.
   - **title**: The display title in the navigation. This can differ from the page's \`title\` frontmatter.
+  - **icon**: Optional Lucide icon name shown next to the link.
+  - **links**: Optional array of nested child links. See [Nested navigation](#nested-navigation).
+
+## Icons
+
+Add icons to categories and links to make the sidebar easier to scan. Icons use [Lucide](https://lucide.dev/icons) names in kebab-case (e.g. \`rocket\`, \`book-open\`, \`settings\`). Unknown names render nothing, so a typo never breaks the build.
+
+With frontmatter, set \`navIcon\` on a page for its sidebar link and \`categoryIcon\` for its category:
+
+\`\`\`text
+---
+title: "Introduction"
+category: "Getting Started"
+categoryOrder: 1
+order: 1
+navIcon: "rocket"
+categoryIcon: "book-open"
+---
+\`\`\`
+
+With \`navigation.json\`, add an \`icon\` to any category or link:
+
+\`\`\`json
+[
+  {
+    "label": "Getting Started",
+    "icon": "book-open",
+    "links": [
+      { "slug": "", "title": "Introduction", "icon": "rocket" },
+      { "slug": "commands", "title": "Commands", "icon": "terminal" }
+    ]
+  }
+]
+\`\`\`
+
+## Nested navigation
+
+A link in \`navigation.json\` can hold its own \`links\` array to create a collapsible group. Groups expand and collapse on click and open automatically when one of their pages is active. Nesting can go as deep as you need.
+
+\`\`\`json
+[
+  {
+    "label": "Guides",
+    "icon": "book-open",
+    "links": [
+      { "slug": "guides", "title": "Overview", "icon": "compass" },
+      {
+        "title": "Advanced",
+        "icon": "settings",
+        "links": [
+          { "slug": "guides/caching", "title": "Caching" },
+          { "slug": "guides/streaming", "title": "Streaming" }
+        ]
+      }
+    ]
+  }
+]
+\`\`\`
+
+A group can be a plain label - omit \`slug\` and it acts only as a collapsible header - or a real page, by adding a \`slug\` so the group title is also a link.
+
+<Callout type="note">
+  Nested groups are only available through \`navigation.json\`. Frontmatter navigation is always two levels: category and pages.
+</Callout>
 
 ## Precedence and behavior
 

--- a/src/templates/mdx/platform/build-and-deploy.mdx.ts
+++ b/src/templates/mdx/platform/build-and-deploy.mdx.ts
@@ -4,6 +4,7 @@ description: "Monitor your documentation site's build status and deployment hist
 date: "2026-02-19"
 category: "Infrastructure"
 categoryOrder: 3
+categoryIcon: "server"
 order: 1
 section: "Platform"
 ---

--- a/src/templates/mdx/platform/file-editor.mdx.ts
+++ b/src/templates/mdx/platform/file-editor.mdx.ts
@@ -4,6 +4,7 @@ description: "Browse, create, and edit your documentation files directly in the 
 date: "2026-02-19"
 category: "Editing"
 categoryOrder: 1
+categoryIcon: "pencil"
 order: 0
 section: "Platform"
 ---

--- a/src/templates/mdx/platform/index.mdx.ts
+++ b/src/templates/mdx/platform/index.mdx.ts
@@ -4,6 +4,7 @@ description: "Learn how to use the Doccupine platform to create, customize, and 
 date: "2026-02-19"
 category: "Getting Started"
 categoryOrder: 0
+categoryIcon: "rocket"
 order: 0
 section: "Platform"
 ---

--- a/src/templates/mdx/platform/project-settings.mdx.ts
+++ b/src/templates/mdx/platform/project-settings.mdx.ts
@@ -4,6 +4,7 @@ description: "Rename or delete your documentation project."
 date: "2026-02-19"
 category: "Account"
 categoryOrder: 4
+categoryIcon: "user"
 order: 2
 section: "Platform"
 ---

--- a/src/templates/mdx/platform/site-settings.mdx.ts
+++ b/src/templates/mdx/platform/site-settings.mdx.ts
@@ -4,6 +4,7 @@ description: "Configure your documentation site's name, description, icon, and i
 date: "2026-02-19"
 category: "Configuration"
 categoryOrder: 2
+categoryIcon: "settings"
 order: 0
 section: "Platform"
 ---

--- a/src/templates/mdx/tabs.mdx.ts
+++ b/src/templates/mdx/tabs.mdx.ts
@@ -19,7 +19,7 @@ You can use the Tabs component directly within your MDX files without any import
 
 \`\`\`\`mdx
 <Tabs>
-  <TabContent title="First tab">
+  <TabContent title="First tab" icon="code">
     ☝️ This is the content shown only when the first tab is active.
 
     Tabs can include all kinds of components. For example, a simple Java program:
@@ -32,17 +32,17 @@ You can use the Tabs component directly within your MDX files without any import
     \`\`\`
 
   </TabContent>
-  <TabContent title="Second tab">
+  <TabContent title="Second tab" icon="book-open">
     ✌️ Content inside this second tab is separate from the first.
   </TabContent>
-  <TabContent title="Third tab">
+  <TabContent title="Third tab" icon="rocket">
     💪 This third tab contains its own unique content.
   </TabContent>
 </Tabs>
 \`\`\`\`
 
 <Tabs>
-  <TabContent title="First tab">
+  <TabContent title="First tab" icon="code">
     ☝️ This is the content shown only when the first tab is active.
 
     Tabs can include all kinds of components. For example, a simple Java program:
@@ -55,18 +55,25 @@ You can use the Tabs component directly within your MDX files without any import
     \`\`\`
 
   </TabContent>
-  <TabContent title="Second tab">
+  <TabContent title="Second tab" icon="book-open">
     ✌️ Content inside this second tab is separate from the first.
   </TabContent>
-  <TabContent title="Third tab">
+  <TabContent title="Third tab" icon="rocket">
     💪 This third tab contains its own unique content.
   </TabContent>
 </Tabs>
+
+Each tab also accepts an optional \`icon\` - any [Lucide](https://lucide.dev/icons) icon name - rendered before its title, as shown above.
 
 ## Properties
 
 <Field value="title" type="string">
   The title of the tab.
+</Field>
+
+<Field value="icon" type="string">
+  Optional [Lucide](https://lucide.dev/icons) icon name (kebab-case, e.g.
+  \`rocket\`) shown next to the tab title.
 </Field>
 
 <Field value="children" type="node" required>

--- a/src/templates/utils/orderNavItems.ts
+++ b/src/templates/utils/orderNavItems.ts
@@ -8,16 +8,20 @@ export const orderNavItemsTemplate = `export interface PagesProps {
   categoryOrder?: number;
   order?: number;
   section?: string;
+  navIcon?: string;
+  categoryIcon?: string;
 }
 
 interface AccProps {
   [key: string]: {
     categoryOrder: number;
+    icon?: string;
     pages: {
       date: string | null;
       slug: string;
       title: string;
       order: number;
+      icon?: string;
     }[];
   };
 }
@@ -33,11 +37,17 @@ function transformPagesToGroupedStructure(pages: PagesProps[]) {
       };
     }
 
+    // The first page in a category to declare a categoryIcon sets it.
+    if (!acc[category].icon && page.categoryIcon) {
+      acc[category].icon = page.categoryIcon;
+    }
+
     acc[category].pages.push({
       date: page.date,
       slug: page.slug,
       title: page.title,
       order: page.order || 0,
+      icon: page.navIcon,
     });
 
     return acc;
@@ -48,6 +58,7 @@ function transformPagesToGroupedStructure(pages: PagesProps[]) {
     .map(([categoryName, categoryData], index) => ({
       slug: index === 0 ? "" : categoryName.toLowerCase().replace(/s+/g, "-"),
       label: categoryName,
+      icon: categoryData.icon,
       links: categoryData.pages.sort((a, b) => a.order - b.order),
     }));
 }


### PR DESCRIPTION
## Summary

Adds icon support and nested navigation to the generated docs site, plus collision-free heading/TOC anchors. All changes are in the CLI source and its string templates under `src/`.

## Changes

- **Unique heading/TOC anchors** — new shared slugger `src/templates/components/layout/Slug.ts` (`slugify` + `createSlugger`). The right-hand "On this page" sidebar (`Docs.ts`), rendered MDX headings (`MDXComponents.ts`), and `<Update>` blocks (`Update.ts`) now share one document-order slugger, so duplicate heading text yields unique, matching ids (`setup`, `setup-1`, ...). Registered in `structures.ts`.
- **`<Update>` label is a copyable anchor link** — right-click → "Copy link address" gives the deep link; left-click scrolls to the block (`Update.ts`).
- **Left sidebar navigation icons** — categories and links can show a Lucide icon via `navIcon` (per-page link) and `categoryIcon` (per-category) frontmatter, and `icon` on categories/links in `navigation.json`. Threaded through `types.ts`, `index.ts` (`parseMDXFile`), and `orderNavItems.ts`; rendered in `SideBar.ts` / `DocsComponents.ts`; types widened in `SectionNavProvider.ts`. Kept separate from the existing favicon/OG `icon` field.
- **Nested collapsible navigation** — a `navigation.json` link can hold its own `links[]` to form a collapsible group, animated open/close (height `0 ↔ auto`, same mechanism as the Accordion) with link-style hover and a rotating chevron. The prev/next pager (`DocsNavigation.ts`) recursively flattens nested links.
- **Default docs category icons** — added `categoryIcon` on representative pages (`index.mdx`, `components.mdx`, `globals.mdx`, and the `platform/*` sections), with an empty-state fallback icon in `layout.ts` and `SectionNavProvider.ts`.
- **Tab title icons** — `TabContent` accepts an optional `icon` prop, rendered (18px) beside the tab title (`Tabs.ts`).
- **Docs updates** — `navigation.mdx.ts` documents icons + nested navigation (its array-format example now lists all default pages); `tabs.mdx.ts` documents the tab icon.

## Verification

- `pnpm build` (tsc) passes.
- `pnpm test` — all 20 tests pass.
- Generated Next.js app type-checks and `next build` succeeds.
- All generated output is prettier-stable.
