### PR TITLE
fix: eliminate chat 524 timeouts and precompute doc embeddings

### DIFF
--- a/src/lib/structures.ts
+++ b/src/lib/structures.ts
@@ -62,10 +62,12 @@ import { mcpIndexTemplate } from "../templates/services/mcp/index.js";
 import { mcpServerTemplate } from "../templates/services/mcp/server.js";
 import { mcpToolsTemplate } from "../templates/services/mcp/tools.js";
 import { mcpTypesTemplate } from "../templates/services/mcp/types.js";
+import { docsIndexStubTemplate } from "../templates/services/mcp/docsIndexStub.js";
 import { llmConfigTemplate } from "../templates/services/llm/config.js";
 import { llmFactoryTemplate } from "../templates/services/llm/factory.js";
 import { llmIndexTemplate } from "../templates/services/llm/index.js";
 import { llmTypesTemplate } from "../templates/services/llm/types.js";
+import { buildDocsIndexScriptTemplate } from "../templates/scripts/build-docs-index.js";
 
 import { posthogServerTemplate } from "../templates/lib/posthog.js";
 import { siteGateTemplate } from "../templates/lib/siteGate.js";
@@ -148,10 +150,13 @@ export const appStructure: Record<string, string> = {
   "services/mcp/server.ts": mcpServerTemplate,
   "services/mcp/tools.ts": mcpToolsTemplate,
   "services/mcp/types.ts": mcpTypesTemplate,
+  "services/mcp/docs-index.json": docsIndexStubTemplate,
   "services/llm/config.ts": llmConfigTemplate,
   "services/llm/factory.ts": llmFactoryTemplate,
   "services/llm/index.ts": llmIndexTemplate,
   "services/llm/types.ts": llmTypesTemplate,
+
+  "scripts/build-docs-index.mts": buildDocsIndexScriptTemplate,
 
   "types/styled.d.ts": styledDTemplate,
 

--- a/src/templates/app/api/rag/route.ts
+++ b/src/templates/app/api/rag/route.ts
@@ -50,6 +50,12 @@ Each context chunk includes a "URL:" line with the pre-computed page URL. Use it
 ## Greetings & Small Talk
 If the user sends a greeting or non-documentation question, respond briefly and ask how you can help with the documentation.\`;
 
+// LangChain + the MCP SDK require the Node.js runtime (not edge).
+export const runtime = "nodejs";
+// Safety net for the streaming function (Vercel-only; ignored elsewhere).
+// The heartbeat below, not this value, is what prevents proxy 524 timeouts.
+export const maxDuration = 60;
+
 export async function POST(req: Request) {
   // Rate limit by IP
   const ip =
@@ -62,129 +68,153 @@ export async function POST(req: Request) {
     );
   }
 
+  // Validate the request up front so genuine client/config errors still return
+  // real status codes before we commit to a 200 streaming response.
+  let body: unknown;
   try {
-    const body = await req.json();
-    const parsed = ragSchema.safeParse(body);
-    if (!parsed.success) {
-      return NextResponse.json(
-        { error: "Invalid input", details: parsed.error.issues },
-        { status: 400 },
-      );
-    }
-    const { question, history, refresh } = parsed.data;
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
 
-    let llmConfig;
-    try {
-      llmConfig = getLLMConfig();
-    } catch (error: unknown) {
-      const message =
-        error instanceof Error ? error.message : "LLM configuration error";
-      return NextResponse.json({ error: message }, { status: 500 });
-    }
+  const parsed = ragSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid input", details: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+  const { question, history, refresh } = parsed.data;
 
-    // Use MCP service to ensure docs are indexed
-    await ensureDocsIndex(Boolean(refresh));
-
-    // Use MCP search_docs tool to find relevant documentation
-    const searchResults = await searchDocs(question, 6);
-
-    // Build context from search results
-    const context = searchResults
-      .map(({ chunk, score }) => {
-        const slug = chunk.uri.replace("docs://", "").replace(/^\\/+/, "");
-        const url = slug ? \`/\${slug}/\` : "/";
-        return \`File: \${chunk.path}\\nURL: \${url}\\nScore: \${score.toFixed(3)}\\n----\\n\${chunk.text}\`;
-      })
-      .join("\\n\\n================\\n\\n");
-
-    // Create chat model and stream response
-    const llm = createChatModel(llmConfig);
-    const prompt: { role: "system" | "user" | "assistant"; content: string }[] =
-      [
-        {
-          role: "system" as const,
-          content: systemContext,
-        },
-      ];
-
-    // Include conversation history for multi-turn context
-    if (history && history.length > 0) {
-      for (const msg of history) {
-        prompt.push({
-          role: msg.role,
-          content: msg.content,
-        });
-      }
-    }
-
-    prompt.push({
-      role: "user" as const,
-      content: \`Question: \${question}\\n\\nContext:\\n\${context}\`,
-    });
-
-    const stream = await llm.stream(prompt);
-
-    // Build metadata from MCP search results
-    const indexStatus = getIndexStatus();
-    const metadata = {
-      sources: searchResults.map(({ chunk, score }) => ({
-        id: chunk.id,
-        path: chunk.path,
-        uri: chunk.uri,
-        score,
-      })),
-      chunkCount: indexStatus.chunkCount,
-    };
-
-    const encoder = new TextEncoder();
-    const readableStream = new ReadableStream({
-      async start(controller) {
-        try {
-          controller.enqueue(
-            encoder.encode(
-              \`data: \${JSON.stringify({ type: "metadata", data: metadata })}\\n\\n\`,
-            ),
-          );
-
-          for await (const chunk of stream) {
-            const content = chunk?.content || "";
-            if (content) {
-              controller.enqueue(
-                encoder.encode(
-                  \`data: \${JSON.stringify({ type: "content", data: content })}\\n\\n\`,
-                ),
-              );
-            }
-          }
-
-          controller.enqueue(
-            encoder.encode(\`data: \${JSON.stringify({ type: "done" })}\\n\\n\`),
-          );
-          controller.close();
-        } catch (error: unknown) {
-          const message =
-            error instanceof Error ? error.message : "Stream error";
-          controller.enqueue(
-            encoder.encode(
-              \`data: \${JSON.stringify({ type: "error", data: message })}\\n\\n\`,
-            ),
-          );
-          controller.close();
-        }
-      },
-    });
-
-    return new Response(readableStream, {
-      headers: {
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache",
-        Connection: "keep-alive",
-      },
-    });
-  } catch (e: unknown) {
-    const message = e instanceof Error ? e.message : "Unknown error";
+  let llmConfig;
+  try {
+    llmConfig = getLLMConfig();
+  } catch (error: unknown) {
+    const message =
+      error instanceof Error ? error.message : "LLM configuration error";
     return NextResponse.json({ error: message }, { status: 500 });
   }
+
+  const encoder = new TextEncoder();
+  let heartbeat: ReturnType<typeof setInterval> | null = null;
+  let streamClosed = false;
+
+  // Return the streaming response immediately and do ALL slow work (indexing,
+  // search, model streaming) inside start(). This flushes headers + a first
+  // byte right away so edge proxies never hit their time-to-first-byte timeout.
+  const readableStream = new ReadableStream({
+    async start(controller) {
+      const safeEnqueue = (payload: string) => {
+        if (streamClosed) return;
+        try {
+          controller.enqueue(encoder.encode(payload));
+        } catch {
+          // Stream already closed or cancelled - stop emitting.
+          streamClosed = true;
+          if (heartbeat) clearInterval(heartbeat);
+        }
+      };
+
+      // Keep the connection alive while the index and model warm up.
+      heartbeat = setInterval(() => safeEnqueue(\`: keep-alive\\n\\n\`), 15000);
+
+      try {
+        // First byte, before any slow work - satisfies the proxy TTFB window.
+        safeEnqueue(\`: connected\\n\\n\`);
+
+        // Ensure docs are indexed (loads precomputed embeddings when present).
+        await ensureDocsIndex(Boolean(refresh));
+
+        // Use MCP search_docs tool to find relevant documentation
+        const searchResults = await searchDocs(question, 6);
+
+        // Build context from search results
+        const context = searchResults
+          .map(({ chunk, score }) => {
+            const slug = chunk.uri.replace("docs://", "").replace(/^\\/+/, "");
+            const url = slug ? \`/\${slug}/\` : "/";
+            return \`File: \${chunk.path}\\nURL: \${url}\\nScore: \${score.toFixed(3)}\\n----\\n\${chunk.text}\`;
+          })
+          .join("\\n\\n================\\n\\n");
+
+        // Build metadata from MCP search results and send it before the answer.
+        const indexStatus = getIndexStatus();
+        const metadata = {
+          sources: searchResults.map(({ chunk, score }) => ({
+            id: chunk.id,
+            path: chunk.path,
+            uri: chunk.uri,
+            score,
+          })),
+          chunkCount: indexStatus.chunkCount,
+        };
+        safeEnqueue(
+          \`data: \${JSON.stringify({ type: "metadata", data: metadata })}\\n\\n\`,
+        );
+
+        // Assemble the prompt, including conversation history for multi-turn.
+        const prompt: {
+          role: "system" | "user" | "assistant";
+          content: string;
+        }[] = [
+          {
+            role: "system" as const,
+            content: systemContext,
+          },
+        ];
+        if (history && history.length > 0) {
+          for (const msg of history) {
+            prompt.push({
+              role: msg.role,
+              content: msg.content,
+            });
+          }
+        }
+        prompt.push({
+          role: "user" as const,
+          content: \`Question: \${question}\\n\\nContext:\\n\${context}\`,
+        });
+
+        // Create chat model and stream the response.
+        const llm = createChatModel(llmConfig);
+        const stream = await llm.stream(prompt);
+        for await (const chunk of stream) {
+          const content = chunk?.content || "";
+          if (content) {
+            safeEnqueue(
+              \`data: \${JSON.stringify({ type: "content", data: content })}\\n\\n\`,
+            );
+          }
+        }
+
+        safeEnqueue(\`data: \${JSON.stringify({ type: "done" })}\\n\\n\`);
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : "Stream error";
+        safeEnqueue(
+          \`data: \${JSON.stringify({ type: "error", data: message })}\\n\\n\`,
+        );
+      } finally {
+        if (heartbeat) clearInterval(heartbeat);
+        streamClosed = true;
+        try {
+          controller.close();
+        } catch {
+          // Already closed.
+        }
+      }
+    },
+    cancel() {
+      streamClosed = true;
+      if (heartbeat) clearInterval(heartbeat);
+    },
+  });
+
+  return new Response(readableStream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+    },
+  });
 }
 
 export async function GET() {

--- a/src/templates/components/Chat.ts
+++ b/src/templates/components/Chat.ts
@@ -1033,8 +1033,21 @@ const ChtProvider = ({ children, isChatActive }: ChatContextProviderProps) => {
       });
 
       if (!res.ok) {
-        const errorData = await res.json();
-        throw new Error(errorData.error || "Request failed");
+        // The body may be a proxy/gateway HTML error page (e.g. Cloudflare
+        // 524), not our JSON - never blindly JSON.parse it.
+        const contentType = res.headers.get("content-type") || "";
+        let message = "Request failed";
+        if (contentType.includes("application/json")) {
+          try {
+            const errorData = await res.json();
+            message = errorData.error || message;
+          } catch {
+            // Non-JSON despite the header - fall through to the default.
+          }
+        } else if ([502, 503, 504, 524].includes(res.status)) {
+          message = "The assistant took too long to respond. Please try again.";
+        }
+        throw new Error(message);
       }
 
       const reader = res.body?.getReader();

--- a/src/templates/gitignore.ts
+++ b/src/templates/gitignore.ts
@@ -38,4 +38,7 @@ next-env.d.ts
 
 .env
 .vscode
+
+# generated build artifact (precomputed embeddings)
+services/mcp/docs-index.json
 `;

--- a/src/templates/next.config.ts
+++ b/src/templates/next.config.ts
@@ -13,6 +13,12 @@ const nextConfig: NextConfig = {
   compiler: {
     styledComponents: true,
   },
+  // Bundle the precomputed embeddings index into the serverless functions that
+  // read it (a dynamic fs read is invisible to Next's file tracing).
+  outputFileTracingIncludes: {
+    "/api/rag": ["./services/mcp/docs-index.json"],
+    "/api/mcp": ["./services/mcp/docs-index.json"],
+  },
 };
 
 export default nextConfig;
@@ -30,6 +36,12 @@ export default nextConfig;
 const nextConfig: NextConfig = {
   compiler: {
     styledComponents: true,
+  },
+  // Bundle the precomputed embeddings index into the serverless functions that
+  // read it (a dynamic fs read is invisible to Next's file tracing).
+  outputFileTracingIncludes: {
+    "/api/rag": ["./services/mcp/docs-index.json"],
+    "/api/mcp": ["./services/mcp/docs-index.json"],
   },
   async rewrites() {
     return [

--- a/src/templates/package.ts
+++ b/src/templates/package.ts
@@ -6,7 +6,7 @@ export const packageJsonTemplate =
       private: true,
       scripts: {
         dev: "next dev",
-        build: "next build",
+        build: "tsx scripts/build-docs-index.mts && next build",
         start: "next start",
         lint: "eslint .",
         format: "prettier --write .",
@@ -39,6 +39,7 @@ export const packageJsonTemplate =
         zod: "^4.4.3",
       },
       devDependencies: {
+        "@next/env": "16.2.10",
         "@next/eslint-plugin-next": "16.2.10",
         "@types/node": "^26",
         "@types/react": "^19",
@@ -53,6 +54,7 @@ export const packageJsonTemplate =
         "eslint-plugin-react-hooks": "^7.1.1",
         globals: "^17.7.0",
         prettier: "^3.9.5",
+        tsx: "^4.23.0",
         typescript: "npm:@typescript/typescript6@^6.0.2",
       },
     },

--- a/src/templates/pnpmWorkspace.ts
+++ b/src/templates/pnpmWorkspace.ts
@@ -1,5 +1,6 @@
 export const pnpmWorkspaceTemplate = `allowBuilds:
   core-js: false
+  esbuild: false
   protobufjs: false
   sharp: false
   unrs-resolver: false

--- a/src/templates/prettierignore.ts
+++ b/src/templates/prettierignore.ts
@@ -5,4 +5,5 @@ package.json
 package-lock.json
 pnpm-lock.yaml
 pnpm-workspace.yaml
+services/mcp/docs-index.json
 `;

--- a/src/templates/scripts/build-docs-index.ts
+++ b/src/templates/scripts/build-docs-index.ts
@@ -1,0 +1,81 @@
+export const buildDocsIndexScriptTemplate = `/**
+ * Precompute document embeddings at build time.
+ *
+ * Runs before \`next build\` (wired into the "build" script in package.json).
+ * Embeds every docs chunk once and writes services/mcp/docs-index.json, so the
+ * running app loads vectors instead of re-embedding the whole doc set on every
+ * serverless cold start (the main cause of slow first chats / proxy timeouts).
+ *
+ * Fails soft: without an API key, or on any embedding error, it leaves the
+ * existing (possibly empty) index in place and exits 0 so the build proceeds.
+ * The app then falls back to embedding on demand at runtime.
+ */
+import path from "node:path";
+import { writeFileSync } from "node:fs";
+// @next/env is CommonJS; use a default import so the named export resolves
+// under tsx's ESM loader (a named import is not statically detected).
+import nextEnv from "@next/env";
+import { getAllDocsChunks } from "../services/mcp/tools";
+import { getLLMConfig, isLLMAvailable } from "../services/llm/config";
+import { createEmbeddings } from "../services/llm/factory";
+
+// This runs as a standalone process before \`next build\`, so it must load
+// .env / .env.local / .env.production itself (the same way Next does). Real
+// environment variables still take precedence over .env files.
+nextEnv.loadEnvConfig(process.cwd());
+
+const OUTPUT = path.join(process.cwd(), "services", "mcp", "docs-index.json");
+const BATCH_SIZE = 10;
+
+async function main() {
+  if (!isLLMAvailable()) {
+    console.warn(
+      "[doccupine] No LLM API key set - skipping embedding precompute. " +
+        "The chat will embed docs on demand at runtime.",
+    );
+    return;
+  }
+
+  const chunks = await getAllDocsChunks();
+  if (chunks.length === 0) {
+    console.warn("[doccupine] No docs found to embed - skipping precompute.");
+    return;
+  }
+
+  const config = getLLMConfig();
+  const embeddings = createEmbeddings(config);
+
+  // Embed in small batches to stay within provider token limits.
+  const texts = chunks.map((c) => c.text);
+  const vectors: number[][] = [];
+  for (let i = 0; i < texts.length; i += BATCH_SIZE) {
+    const batch = await embeddings.embedDocuments(
+      texts.slice(i, i + BATCH_SIZE),
+    );
+    vectors.push(...batch);
+  }
+
+  const data = {
+    provider: config.provider,
+    embeddingModel: config.embeddingModel,
+    chunks: chunks.map((c, i) => ({ ...c, embedding: vectors[i] })),
+  };
+
+  writeFileSync(OUTPUT, JSON.stringify(data));
+  console.log(
+    \`[doccupine] Precomputed \${data.chunks.length} doc embeddings -> \${OUTPUT}\`,
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    // Never fail the build on an embedding error - fall back to runtime embedding.
+    console.warn(
+      "[doccupine] Embedding precompute failed; continuing build. " +
+        "The chat will embed docs at runtime.",
+      error instanceof Error ? error.message : error,
+    );
+    process.exit(0);
+  });
+`;

--- a/src/templates/services/mcp/docsIndexStub.ts
+++ b/src/templates/services/mcp/docsIndexStub.ts
@@ -1,0 +1,9 @@
+// Placeholder embeddings index. Populated at build time by
+// scripts/build-docs-index.mts; the stub keeps the path present for dev and
+// for outputFileTracingIncludes. Empty chunks -> the app embeds at runtime.
+export const docsIndexStubTemplate = `{
+  "provider": null,
+  "embeddingModel": null,
+  "chunks": []
+}
+`;

--- a/src/templates/services/mcp/server.ts
+++ b/src/templates/services/mcp/server.ts
@@ -1,4 +1,6 @@
-export const mcpServerTemplate = `import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+export const mcpServerTemplate = `import path from "node:path";
+import fs from "node:fs";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import {
   listDocs,
@@ -45,6 +47,45 @@ function cosineSim(a: number[], b: number[]): number {
 }
 
 /**
+ * Absolute path to the embeddings index precomputed at build time by
+ * scripts/build-docs-index.mts. Bundled into serverless functions via
+ * outputFileTracingIncludes in next.config.ts.
+ */
+const INDEX_FILE = path.join(
+  process.cwd(),
+  "services",
+  "mcp",
+  "docs-index.json",
+);
+
+/**
+ * Load embeddings precomputed at build time. Returns null when the file is
+ * missing/empty or was built with a different provider/model than the current
+ * config - query and document vectors must come from the same embedding model.
+ */
+function loadPrecomputedIndex():
+  (DocsChunk & { embedding: number[] })[] | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(INDEX_FILE, "utf8")) as {
+      provider?: string;
+      embeddingModel?: string;
+      chunks?: (DocsChunk & { embedding: number[] })[];
+    };
+    if (!parsed.chunks || parsed.chunks.length === 0) return null;
+    const config = getLLMConfig();
+    if (
+      parsed.provider !== config.provider ||
+      parsed.embeddingModel !== config.embeddingModel
+    ) {
+      return null;
+    }
+    return parsed.chunks;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Build or rebuild the documentation index
  */
 async function buildDocsIndex(force = false): Promise<void> {
@@ -53,6 +94,17 @@ async function buildDocsIndex(force = false): Promise<void> {
 
   docsIndex.building = true;
   try {
+    // Prefer embeddings precomputed at build time - avoids re-embedding the
+    // entire doc set on every cold start (the main cause of slow first chats).
+    if (!force) {
+      const precomputed = loadPrecomputedIndex();
+      if (precomputed) {
+        docsIndex.chunks = precomputed;
+        docsIndex.ready = true;
+        return;
+      }
+    }
+
     const chunks = await getAllDocsChunks();
 
     if (chunks.length === 0) {


### PR DESCRIPTION
## Summary

Fixes the intermittent chat failures in the generated docs app (HTTP `524` and `Unexpected token '<' ... is not valid JSON`) and removes their root cause by precomputing document embeddings at build time.

## Changes

### 1. Prevent chat 524 timeouts and JSON parse errors

- **`app/api/rag/route.ts`**: return the SSE streaming `Response` immediately and move all slow work (doc indexing, semantic search, LLM streaming) inside the `ReadableStream` `start()` callback. Flush a `: connected` heartbeat first byte plus a 15s keep-alive interval so edge proxies (Cloudflare) never hit their time-to-first-byte timeout. Request body and LLM config are validated up front so genuine client/config errors still return real `400`/`500` codes; errors after headers are sent become SSE `error` events. Headers use `Cache-Control: no-cache, no-transform`; pins `runtime = "nodejs"` and `maxDuration = 60`.
- **`components/Chat.ts`**: the client no longer blindly `res.json()`s an error response. It checks the content-type and shows a friendly retry message for gateway/HTML error pages.

### 2. Precompute doc embeddings at build time

Re-embedding the entire doc set on every serverless cold start was the underlying cause of slow first chats. Embed once at build time and load the vectors at runtime.

- **`scripts/build-docs-index.mts`** (new): embeds all doc chunks in batches and writes `services/mcp/docs-index.json`. Loads `.env` via `@next/env`; fails soft (no key / API error -> exit 0) so the build always proceeds.
- **`services/mcp/docs-index.json`** (new stub): empty index so the path always exists for dev and file tracing.
- **`services/mcp/server.ts`**: loads the precomputed index via `fs` and only re-embeds at runtime if it is missing or its provider/model do not match the current config.
- **`next.config.ts`**: `outputFileTracingIncludes` bundles the index into the `/api/rag` and `/api/mcp` serverless functions.
- **`package.ts`**: `build` now runs `tsx scripts/build-docs-index.mts && next build`; adds `tsx` and `@next/env` devDependencies.

### 3. Install/build robustness

- **`pnpm-workspace.yaml`**: `esbuild: false` in `allowBuilds` so the `tsx` install does not fail esbuild's build script under the strict policy.
- **`.gitignore` / `.prettierignore`**: ignore the generated `services/mcp/docs-index.json` build artifact.
- **`lib/structures.ts`**: wire the two new templates into the app structure.

## Verification

- CLI builds (`tsc`) and all 20 tests pass.
- A generated app typechecks, `next build` succeeds, and generated files are prettier-clean.