### PR TITLE
fix(config): store doccupine.json paths relative to the project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Place these JSON files in your project root (where you run `doccupine`). They ar
 
 | File              | Purpose                                                                                                   |
 | ----------------- | --------------------------------------------------------------------------------------------------------- |
-| `doccupine.json`  | CLI config (watchDir, outputDir, port). Auto-generated on first run.                                      |
+| `doccupine.json`  | CLI config (watchDir, outputDir, port). Auto-generated on first run. Paths are stored relative to the project root, so the file is safe to commit. |
 | `config.json`     | Site metadata: `name`, `description`, `icon`, `image`, `url` (public site URL for sitemap/robots)         |
 | `theme.json`      | Theme overrides for [cherry-styled-components](https://github.com/cherry-design-system/styled-components) |
 | `navigation.json` | Manual navigation structure (overrides auto-generated)                                                    |

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,21 @@
 import { describe, it, expect } from "vitest";
-import { generateSlug, escapeTemplateContent, getFullSlug } from "./index.js";
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { fileURLToPath } from "url";
+
+import {
+  generateSlug,
+  escapeTemplateContent,
+  getFullSlug,
+  isProcessEntrypoint,
+} from "./index.js";
+
+const execFileAsync = promisify(execFile);
+const selfPath = fileURLToPath(import.meta.url);
+const distEntry = path.resolve(selfPath, "..", "..", "dist", "index.js");
 
 describe("generateSlug", () => {
   it("returns empty string for index.mdx", () => {
@@ -91,3 +107,74 @@ describe("escapeTemplateContent", () => {
     expect(escapeTemplateContent("")).toBe("");
   });
 });
+
+describe("isProcessEntrypoint", () => {
+  it("is false while this module is merely imported", () => {
+    // Guards the reason it exists: importing index.js for its helpers must not
+    // parse argv and fall through to the default `watch` command.
+    expect(isProcessEntrypoint()).toBe(false);
+  });
+
+  it("is true when the entry names this file directly", () => {
+    expect(isProcessEntrypoint(selfPath, selfPath)).toBe(true);
+  });
+
+  it("is true when the entry is a symlink to this file", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "doccupine-bin-"));
+    const link = path.join(tempDir, "doccupine");
+
+    try {
+      // Mirrors how npm installs the bin: node_modules/.bin/doccupine is a
+      // symlink, so argv[1] and import.meta.url name the same file differently.
+      await fs.symlink(selfPath, link);
+      expect(isProcessEntrypoint(link, selfPath)).toBe(true);
+    } finally {
+      await fs.remove(tempDir);
+    }
+  });
+
+  it("is false for a different file", () => {
+    expect(
+      isProcessEntrypoint(
+        path.join(path.dirname(selfPath), "index.ts"),
+        selfPath,
+      ),
+    ).toBe(false);
+  });
+
+  it("is false when the entry is missing or does not exist", () => {
+    expect(isProcessEntrypoint(undefined, selfPath)).toBe(false);
+    expect(isProcessEntrypoint("", selfPath)).toBe(false);
+    expect(isProcessEntrypoint("/nonexistent/doccupine-bin", selfPath)).toBe(
+      false,
+    );
+  });
+});
+
+// Runs against the compiled output, so it needs a build. CI always runs
+// `pnpm build` before `pnpm test`, and `pnpm install` builds via `prepare`.
+describe.skipIf(!fs.pathExistsSync(distEntry))(
+  "compiled CLI entrypoint",
+  () => {
+    it("still parses argv when run directly", async () => {
+      const { stdout } = await execFileAsync(process.execPath, [
+        distEntry,
+        "--version",
+      ]);
+
+      expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+    });
+
+    it("does nothing when imported by another process", async () => {
+      const { stdout, stderr } = await execFileAsync(process.execPath, [
+        "--input-type=module",
+        "-e",
+        `await import(${JSON.stringify(distEntry)});`,
+      ]);
+
+      // A config prompt or watcher startup here means the guard regressed.
+      expect(stdout).toBe("");
+      expect(stderr).toBe("");
+    });
+  },
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1690,6 +1690,9 @@ program
       config.outputDir,
     );
 
+    // Config paths are project-relative; child processes get an absolute cwd.
+    const outputDir = path.resolve(process.cwd(), config.outputDir);
+
     await generator.init();
 
     let devServer: ReturnType<typeof spawn> | null = null;
@@ -1707,7 +1710,7 @@ program
     console.log(chalk.blue(`📦 Using ${packageManager.name}...`));
 
     const install = spawn(packageManager.bin, ["install"], {
-      cwd: config.outputDir,
+      cwd: outputDir,
       stdio: "inherit",
     });
 
@@ -1744,7 +1747,7 @@ program
         ? ["run", "dev", "--", "--port", portStr]
         : ["run", "dev", "--port", portStr];
     devServer = spawn(packageManager.bin, devArgs, {
-      cwd: config.outputDir,
+      cwd: outputDir,
       stdio: ["ignore", "pipe", "pipe"],
     });
 
@@ -1858,4 +1861,36 @@ program
     }
   });
 
-program.parse();
+/**
+ * True when this file is what node was asked to run, rather than a module some
+ * other process imported. The test suite imports this file for its exported
+ * helpers; without this guard, that import parses argv, falls through to the
+ * default `watch` command, and prompts for config / starts file watchers.
+ *
+ * Compares realpaths because npm installs the bin as a symlink
+ * (`node_modules/.bin/doccupine` -> `dist/index.js`), so `process.argv[1]` and
+ * `import.meta.url` can name the same file by different paths.
+ */
+export function isProcessEntrypoint(
+  entry: string | undefined = process.argv[1],
+  self: string = __filename,
+): boolean {
+  if (!entry) return false;
+
+  // Windows paths are case-insensitive; a false negative here would make the
+  // CLI exit silently without running any command.
+  const normalize = (filePath: string) =>
+    process.platform === "win32" ? filePath.toLowerCase() : filePath;
+
+  try {
+    return (
+      normalize(fs.realpathSync(entry)) === normalize(fs.realpathSync(self))
+    );
+  } catch {
+    return false;
+  }
+}
+
+if (isProcessEntrypoint()) {
+  program.parse();
+}

--- a/src/lib/config-manager.test.ts
+++ b/src/lib/config-manager.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+
+import {
+  ConfigManager,
+  normalizeConfigPaths,
+  toProjectRelativePath,
+} from "./config-manager.js";
+
+const ROOT = "/home/dev/project";
+
+describe("toProjectRelativePath", () => {
+  it("rewrites an absolute path inside the root as relative", () => {
+    expect(toProjectRelativePath(`${ROOT}/docs`, ROOT)).toBe("docs");
+    expect(toProjectRelativePath(`${ROOT}/apps/site/docs`, ROOT)).toBe(
+      "apps/site/docs",
+    );
+  });
+
+  it("returns '.' when the path is the root itself", () => {
+    expect(toProjectRelativePath(ROOT, ROOT)).toBe(".");
+  });
+
+  it("keeps absolute paths that escape the root", () => {
+    expect(toProjectRelativePath("/home/dev/other/docs", ROOT)).toBe(
+      "/home/dev/other/docs",
+    );
+    expect(toProjectRelativePath("/home/dev", ROOT)).toBe("/home/dev");
+  });
+
+  it("leaves already-relative paths untouched", () => {
+    expect(toProjectRelativePath("docs", ROOT)).toBe("docs");
+    expect(toProjectRelativePath("./docs", ROOT)).toBe("./docs");
+    expect(toProjectRelativePath("../shared/docs", ROOT)).toBe(
+      "../shared/docs",
+    );
+  });
+
+  it("leaves empty or non-string values untouched", () => {
+    expect(toProjectRelativePath("", ROOT)).toBe("");
+    expect(
+      toProjectRelativePath(undefined as unknown as string, ROOT),
+    ).toBeUndefined();
+  });
+
+  it("produces a value that resolves back to the original path", () => {
+    const original = path.join(ROOT, "content", "docs");
+    const relative = toProjectRelativePath(original, ROOT);
+    expect(path.resolve(ROOT, relative)).toBe(original);
+  });
+});
+
+describe("normalizeConfigPaths", () => {
+  it("flags a config that used absolute paths and rewrites both dirs", () => {
+    const { config, changed } = normalizeConfigPaths(
+      {
+        watchDir: `${ROOT}/docs`,
+        outputDir: `${ROOT}/nextjs-app`,
+        port: "3000",
+        packageManager: "pnpm",
+      },
+      ROOT,
+    );
+
+    expect(changed).toBe(true);
+    expect(config.watchDir).toBe("docs");
+    expect(config.outputDir).toBe("nextjs-app");
+    expect(config.port).toBe("3000");
+    expect(config.packageManager).toBe("pnpm");
+  });
+
+  it("reports no change for an already-relative config", () => {
+    const { config, changed } = normalizeConfigPaths(
+      { watchDir: "docs", outputDir: "nextjs-app", port: "3000" },
+      ROOT,
+    );
+
+    expect(changed).toBe(false);
+    expect(config.watchDir).toBe("docs");
+  });
+
+  it("flags a change when only one of the two dirs is absolute", () => {
+    const { config, changed } = normalizeConfigPaths(
+      { watchDir: "docs", outputDir: `${ROOT}/nextjs-app`, port: "3000" },
+      ROOT,
+    );
+
+    expect(changed).toBe(true);
+    expect(config.outputDir).toBe("nextjs-app");
+  });
+
+  it("does not rewrite an out-of-tree watch directory", () => {
+    const { config, changed } = normalizeConfigPaths(
+      { watchDir: "/var/shared/docs", outputDir: "nextjs-app", port: "3000" },
+      ROOT,
+    );
+
+    expect(changed).toBe(false);
+    expect(config.watchDir).toBe("/var/shared/docs");
+  });
+});
+
+describe("ConfigManager migration", () => {
+  let tempDir: string;
+  let previousCwd: string;
+
+  beforeEach(async () => {
+    previousCwd = process.cwd();
+    // realpath: macOS resolves /var -> /private/var, and process.cwd() reports
+    // the resolved path, so path.relative would otherwise never match.
+    tempDir = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "doccupine-config-")),
+    );
+    process.chdir(tempDir);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    process.chdir(previousCwd);
+    vi.restoreAllMocks();
+    await fs.remove(tempDir);
+  });
+
+  const readConfigFile = async () =>
+    fs.readFile(path.join(tempDir, "doccupine.json"), "utf8");
+
+  it("rewrites a legacy absolute-path config on disk", async () => {
+    await fs.writeJSON(path.join(tempDir, "doccupine.json"), {
+      watchDir: path.join(tempDir, "docs"),
+      outputDir: path.join(tempDir, "nextjs-app"),
+      port: "3000",
+    });
+
+    const config = await new ConfigManager().getConfig();
+
+    expect(config.watchDir).toBe("docs");
+    expect(config.outputDir).toBe("nextjs-app");
+
+    const onDisk = JSON.parse(await readConfigFile());
+    expect(onDisk.watchDir).toBe("docs");
+    expect(onDisk.outputDir).toBe("nextjs-app");
+    expect(onDisk.port).toBe("3000");
+  });
+
+  it("migrated paths still resolve to the original directories", async () => {
+    const watchDir = path.join(tempDir, "content", "docs");
+    await fs.writeJSON(path.join(tempDir, "doccupine.json"), {
+      watchDir,
+      outputDir: path.join(tempDir, "nextjs-app"),
+      port: "3000",
+    });
+
+    const config = await new ConfigManager().getConfig();
+
+    expect(path.resolve(process.cwd(), config.watchDir)).toBe(watchDir);
+  });
+
+  it("leaves an already-relative config file untouched", async () => {
+    const original = `{"watchDir":"docs","outputDir":"nextjs-app","port":"3000"}`;
+    await fs.writeFile(path.join(tempDir, "doccupine.json"), original, "utf8");
+
+    const config = await new ConfigManager().getConfig();
+
+    expect(config.watchDir).toBe("docs");
+    // Byte-identical: no rewrite happened, so committed configs stay stable.
+    expect(await readConfigFile()).toBe(original);
+  });
+
+  it("preserves an out-of-tree absolute watch directory", async () => {
+    await fs.writeJSON(path.join(tempDir, "doccupine.json"), {
+      watchDir: "/var/shared/docs",
+      outputDir: path.join(tempDir, "nextjs-app"),
+      port: "3000",
+    });
+
+    const config = await new ConfigManager().getConfig();
+
+    expect(config.watchDir).toBe("/var/shared/docs");
+    expect(config.outputDir).toBe("nextjs-app");
+  });
+
+  it("keeps other config fields through a migration", async () => {
+    await fs.writeJSON(path.join(tempDir, "doccupine.json"), {
+      watchDir: path.join(tempDir, "docs"),
+      outputDir: path.join(tempDir, "nextjs-app"),
+      port: "4000",
+      packageManager: "npm",
+    });
+
+    const config = await new ConfigManager().getConfig();
+
+    expect(config.port).toBe("4000");
+    expect(config.packageManager).toBe("npm");
+  });
+});

--- a/src/lib/config-manager.ts
+++ b/src/lib/config-manager.ts
@@ -5,6 +5,55 @@ import prompts from "prompts";
 
 import type { DoccupineConfig } from "./types.js";
 
+/**
+ * Rewrites a path as project-relative so `doccupine.json` stays portable
+ * across machines, CI and containers (an absolute `/Users/you/...` breaks for
+ * every other contributor and leaks the local directory layout).
+ *
+ * Paths outside the project root have no portable form, so they are kept
+ * absolute - reads go through `path.resolve()`, which accepts both.
+ */
+export function toProjectRelativePath(
+  targetPath: string,
+  rootDir: string = process.cwd(),
+): string {
+  // A hand-edited config can hold anything; leave junk untouched rather than
+  // throwing inside path.*.
+  if (typeof targetPath !== "string" || !targetPath) return targetPath;
+  if (!path.isAbsolute(targetPath)) return targetPath;
+
+  const relativePath = path.relative(rootDir, targetPath);
+
+  // Empty means the path *is* the root; ".." or an absolute result (Windows
+  // cross-drive) means it escapes the root - neither is portable.
+  if (!relativePath) return ".";
+  if (relativePath === ".." || relativePath.startsWith(`..${path.sep}`)) {
+    return targetPath;
+  }
+  if (path.isAbsolute(relativePath)) return targetPath;
+
+  // Always store POSIX separators so a config written on Windows still
+  // resolves on macOS/Linux.
+  return relativePath.split(path.sep).join("/");
+}
+
+/**
+ * Migrates configs written by older versions, which stored absolute paths.
+ * Returns the normalized config plus whether anything actually changed, so
+ * callers only rewrite the file when needed.
+ */
+export function normalizeConfigPaths(
+  config: DoccupineConfig,
+  rootDir: string = process.cwd(),
+): { config: DoccupineConfig; changed: boolean } {
+  const watchDir = toProjectRelativePath(config.watchDir, rootDir);
+  const outputDir = toProjectRelativePath(config.outputDir, rootDir);
+  const changed =
+    watchDir !== config.watchDir || outputDir !== config.outputDir;
+
+  return { config: { ...config, watchDir, outputDir }, changed };
+}
+
 export class ConfigManager {
   private configPath: string;
 
@@ -34,7 +83,7 @@ export class ConfigManager {
     try {
       await fs.writeFile(
         this.configPath,
-        JSON.stringify(config, null, 2),
+        `${JSON.stringify(config, null, 2)}\n`,
         "utf8",
       );
       console.log(chalk.green("💾 Configuration saved to doccupine.json"));
@@ -70,9 +119,11 @@ export class ConfigManager {
       process.exit(0);
     }
 
+    // Resolve first so "./docs" and "docs/" collapse to the same value, then
+    // store project-relative for portability.
     return {
-      watchDir: path.resolve(process.cwd(), watchDir),
-      outputDir: path.resolve(process.cwd(), outputDir),
+      watchDir: toProjectRelativePath(path.resolve(process.cwd(), watchDir)),
+      outputDir: toProjectRelativePath(path.resolve(process.cwd(), outputDir)),
       port: existingConfig?.port || "3000",
     };
   }
@@ -81,6 +132,7 @@ export class ConfigManager {
     options: { reset?: boolean; port?: string } = {},
   ): Promise<DoccupineConfig> {
     let config: DoccupineConfig | null = null;
+    let dirty = false;
 
     if (!options.reset) {
       config = await this.loadConfig();
@@ -89,11 +141,26 @@ export class ConfigManager {
     if (!config || options.reset) {
       console.log(chalk.blue("🔧 Setting up Doccupine configuration..."));
       config = await this.promptForConfig(config || {});
-      await this.saveConfig(config);
+      dirty = true;
+    } else {
+      // Configs written before 0.0.129 stored absolute paths; rewrite them in
+      // place so the file can be committed and shared.
+      const normalized = normalizeConfigPaths(config);
+      if (normalized.changed) {
+        config = normalized.config;
+        dirty = true;
+        console.log(
+          chalk.blue("🔁 Rewriting doccupine.json paths as project-relative"),
+        );
+      }
     }
 
     if (options.port) {
       config.port = options.port;
+      dirty = true;
+    }
+
+    if (dirty) {
       await this.saveConfig(config);
     }
 


### PR DESCRIPTION
Summary

doccupine.json is auto-generated in the user's project root and is not gitignored, so it gets committed. Until now promptForConfig resolved both directories to absolute paths before saving, producing entries like /Users/luan/Developer/my-docs/docs. That breaks the build for every other contributor, for CI, for Docker, and for Vercel, and it leaks the author's local username and directory layout into a public repo.

This PR stores both paths relative to the project root, migrates existing configs in place, and fixes a related test-suite hazard: src/index.test.ts imports src/index.ts, which ran program.parse() at import time and fell through to the default watch command.

Why relative paths are the correct default

The read side already supported them. MDXToNextJSGenerator calls path.resolve(watchDir) / path.resolve(outputDir), which resolves relative values against process.cwd(), and rootDir is process.cwd() regardless, so public/, sections.json, fonts.json, and analytics.json were already cwd-anchored. Absolute paths in the config bought no extra capability.

The one case that genuinely needs an absolute path is a watch directory outside the project tree. That keeps working: paths that escape the root are stored unchanged, and path.resolve accepts both forms on read.

Changes

src/lib/config-manager.ts

New toProjectRelativePath(targetPath, rootDir) - rewrites an absolute path inside the project root as relative, normalized to POSIX separators so a config written on Windows still resolves on macOS and Linux. Paths that escape the root, already-relative paths, and non-string junk from a hand-edited file pass through untouched. New normalizeConfigPaths(config, rootDir) - returns { config, changed } so callers only rewrite the file when something actually differs. promptForConfig now resolves the user's answer first (collapsing ./docs and docs/ to the same value) and then stores it relative. getConfig migrates a legacy absolute config in place and logs Rewriting doccupine.json paths as project-relative. The save calls are now behind a single dirty flag, so a run that both migrates and applies --port writes the file once instead of twice. saveConfig writes a trailing newline, since this file is meant to be committed.

src/index.ts

Added a resolved outputDir local and pointed both spawn calls (dependency install, dev server) at it. Node would have resolved a relative cwd against process.cwd() anyway, but that was the one place where relative config values were load-bearing without saying so. New isProcessEntrypoint() guard around program.parse(). It compares fs.realpathSync of process.argv[1] against fs.realpathSync(__filename), because npm installs the bin as a symlink (`node_modules/.bin/doccupine` -> dist/index.js`) and the two therefore name the same file by different paths. The compare is case-insensitive on win32. A false negative would make `npx doccupine exit silently with no output and no error, so the predicate deliberately leans toward matching. Both arguments are injectable, which makes it testable without spawning a process.

README.md

Notes that doccupine.json paths are stored relative to the project root and that the file is safe to commit.

Tests

22 new tests, 42 passing overall.

src/lib/config-manager.test.ts (new, 15 tests)

Unit coverage for both helpers, plus five migration tests that run against a real temp directory:

a legacy absolute config is rewritten on disk, and the returned config is relative a migrated value resolves back to the exact original directory an already-relative config file is left byte-identical, so committed configs do not churn an out-of-tree absolute watchDir survives untouched port and packageManager are preserved through a migration The temp directory goes through fs.realpath because macOS reports /private/var from process.cwd() while mkdtemp returns /var; without it every path.relative comparison would be wrong.

src/index.test.ts (7 tests)

Five unit tests on isProcessEntrypoint: false when the module is merely imported (the regression this exists to prevent), true for a direct path, true through a real symlink created in a temp dir, false for a different file, false for missing/empty/nonexistent entries.

Two subprocess tests against the compiled output, which are what would catch a silently dead CLI:

node dist/index.js --version still prints a version, confirming argv parsing is intact when the file is the entrypoint node --input-type=module -e "await import('dist/index.js')" produces empty stdout and stderr, confirming an import starts nothing Those two need a build, so they are wrapped in describe.skipIf(!fs.pathExistsSync(distEntry)). CI runs pnpm build before pnpm test and pnpm install builds via prepare, so they run in practice; verified with --reporter=verbose that they execute rather than skip.

Verification

pnpm build and pnpm test pass (42 tests).
End to end with a real legacy config: wrote a doccupine.json containing absolute paths in a scratch directory, ran doccupine build, and confirmed the site generated correctly, the file was rewritten to "watchDir": "docs" / "outputDir": "nextjs-app", config --show reported the right directories, and a second run did not re-migrate. Symlinked dist/index.js into a fake bin directory and executed through the link, confirming the entrypoint guard resolves symlinks and the CLI still runs.

Migration and compatibility

No action required from users. Existing projects are migrated the next time any command loads the config, which produces a one-line diff in doccupine.json. Absolute paths remain valid on read, so a config that is not migrated (or one that deliberately points outside the project) keeps working.

Notes for the reviewer

The program.parse() guard is a pre-existing bug, confirmed present on a clean tree via git stash. It was harmless only because stdin is not a TTY during test runs; the suite was one step away from writing a doccupine.json into the repo root or starting file watchers. It is included here because the config change is what made the stray prompt visible in test output.

## Summary

<!-- What does this PR do and why? -->

## Related issues

<!-- e.g. Closes #123 -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Template or generated-output change
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] `pnpm build && pnpm test` passes locally
- [x] I tested the change against a real generated app (`node dist/index.js watch` in a scratch directory) when it affects generation
- [x] New templates follow the `camelCaseTemplate` naming convention and are wired into `createNextJSStructure()`
- [x] Generated output is prettier-stable (no formatting churn introduced)
- [x] I did not commit secrets or `.env` files
- [x] The PR is focused on a single feature or fix
