### PR TITLE
fix(analytics): make the edge the single authority for session identity

### DIFF
--- a/src/templates/components/PostHogProviderLazy.ts
+++ b/src/templates/components/PostHogProviderLazy.ts
@@ -40,6 +40,10 @@ const uiHost = (analyticsConfig.posthog?.host || "https://us.i.posthog.com")
  * undefined if absent or malformed, in which case posthog-js mints its own id
  * as before: degraded, never broken.
  */
+// Both the middleware and this file WRITE the session cookie, so these three
+// must stay identical to their counterparts in proxy.ts. They are duplicated
+// rather than shared because a client component cannot import from the
+// middleware. A drifted max-age here would silently expire live sessions.
 const SESSION_COOKIE = "dcp_sid";
 const SESSION_MAX_MS = 24 * 60 * 60 * 1000;
 
@@ -106,30 +110,41 @@ function PostHogInit({ onReady }: { onReady: () => void }) {
   const initRef = useRef(false);
 
   useEffect(() => {
-    if (initRef.current || !posthogKey) return;
-    initRef.current = true;
+    if (!posthogKey) return;
 
-    const sessionID = readEdgeSessionId();
+    // The init guard deliberately does NOT wrap the subscription below.
+    //
+    // Under React StrictMode's dev double-invoke the effect runs, is cleaned
+    // up, then runs again. With an early \`return\` here, that second run would
+    // skip past the subscription and leave \`onSessionId\` permanently
+    // unsubscribed — in dev only, which is precisely where you would go to
+    // check that any of this works. Initialising once while re-subscribing on
+    // every run is correct in both modes.
+    if (!initRef.current) {
+      initRef.current = true;
 
-    posthog.init(posthogKey, {
-      api_host: "/ingest",
-      ui_host: uiHost,
-      capture_pageview: false,
-      capture_pageleave: true,
-      // The middleware owns session identity; this makes the SDK agree with it.
-      ...(sessionID ? { bootstrap: { sessionID } } : {}),
-      loaded: (ph) => {
-        // Write once at startup so a session the middleware adopted (and
-        // therefore did not rewrite) still gets its last-activity advanced.
-        syncSessionCookie(ph.get_session_id());
-        onReady();
-      },
-    });
+      const sessionID = readEdgeSessionId();
+
+      posthog.init(posthogKey, {
+        api_host: "/ingest",
+        ui_host: uiHost,
+        capture_pageview: false,
+        capture_pageleave: true,
+        // The middleware owns session identity; this makes the SDK agree.
+        ...(sessionID ? { bootstrap: { sessionID } } : {}),
+        loaded: (ph) => {
+          // Write once at startup so a session the middleware adopted (and
+          // therefore did not rewrite) still gets its last-activity advanced.
+          syncSessionCookie(ph.get_session_id());
+          onReady();
+        },
+      });
+    }
 
     // Fires when the session id first appears and on every rotation, so the
     // cookie follows posthog-js rather than drifting from it. posthog-js is the
     // better judge of idleness — it sees every captured event, not just
-    // navigations.
+    // navigations. Returning its unsubscribe doubles as the effect cleanup.
     return posthog.onSessionId((id: string) => syncSessionCookie(id));
   }, [onReady]);
 

--- a/src/templates/components/PostHogProviderLazy.ts
+++ b/src/templates/components/PostHogProviderLazy.ts
@@ -40,7 +40,14 @@ const uiHost = (analyticsConfig.posthog?.host || "https://us.i.posthog.com")
  * undefined if absent or malformed, in which case posthog-js mints its own id
  * as before: degraded, never broken.
  */
-function readEdgeSessionId(): string | undefined {
+const SESSION_COOKIE = "dcp_sid";
+const SESSION_MAX_MS = 24 * 60 * 60 * 1000;
+
+function isValidSessionId(id: string): boolean {
+  return /^[0-9a-f]{32}$/i.test(id.replace(/-/g, ""));
+}
+
+function readSessionCookie(): { id: string; startTs: number } | undefined {
   if (typeof document === "undefined") return undefined;
 
   const match = document.cookie.match(/(?:^|;\\s*)dcp_sid=([^;]*)/);
@@ -48,8 +55,51 @@ function readEdgeSessionId(): string | undefined {
 
   // Cookie is \`id.startTs.lastTs\`; posthog-js requires the id be a UUID and
   // logs an error if not, so check before handing it over.
-  const id = decodeURIComponent(match[1]).split(".")[0];
-  return /^[0-9a-f]{32}$/i.test(id.replace(/-/g, "")) ? id : undefined;
+  const [id, startRaw] = decodeURIComponent(match[1]).split(".");
+  const startTs = Number(startRaw);
+  if (!isValidSessionId(id) || !Number.isFinite(startTs)) return undefined;
+
+  return { id, startTs };
+}
+
+function readEdgeSessionId(): string | undefined {
+  return readSessionCookie()?.id;
+}
+
+/**
+ * Keep the session cookie's last-activity fresh, from the browser.
+ *
+ * This is the half of session upkeep the middleware deliberately does NOT do.
+ * A response carrying \`Set-Cookie\` is not cacheable by Vercel's CDN, so
+ * refreshing last-activity server-side would have put one on roughly every doc
+ * page an engaged reader loads. A \`document.cookie\` write sets no response
+ * header at all, so your doc pages stay cacheable — and the browser is the side
+ * that actually sees soft navigations and in-page activity.
+ *
+ * \`startTs\` is carried forward while the id is unchanged, so the 24h hard cap
+ * still measures from when the session really began; a rotation restarts it.
+ */
+function syncSessionCookie(sessionId: string | undefined) {
+  if (typeof document === "undefined" || !sessionId) return;
+  if (!isValidSessionId(sessionId)) return;
+
+  const now = Date.now();
+  const existing = readSessionCookie();
+  const startTs = existing?.id === sessionId ? existing.startTs : now;
+  const secure = location.protocol === "https:" ? "; secure" : "";
+
+  document.cookie =
+    SESSION_COOKIE +
+    "=" +
+    sessionId +
+    "." +
+    startTs +
+    "." +
+    now +
+    "; path=/; max-age=" +
+    SESSION_MAX_MS / 1000 +
+    "; samesite=lax" +
+    secure;
 }
 
 function PostHogInit({ onReady }: { onReady: () => void }) {
@@ -66,10 +116,21 @@ function PostHogInit({ onReady }: { onReady: () => void }) {
       ui_host: uiHost,
       capture_pageview: false,
       capture_pageleave: true,
-      // The edge owns session identity; this makes the SDK agree with it.
+      // The middleware owns session identity; this makes the SDK agree with it.
       ...(sessionID ? { bootstrap: { sessionID } } : {}),
-      loaded: onReady,
+      loaded: (ph) => {
+        // Write once at startup so a session the middleware adopted (and
+        // therefore did not rewrite) still gets its last-activity advanced.
+        syncSessionCookie(ph.get_session_id());
+        onReady();
+      },
     });
+
+    // Fires when the session id first appears and on every rotation, so the
+    // cookie follows posthog-js rather than drifting from it. posthog-js is the
+    // better judge of idleness — it sees every captured event, not just
+    // navigations.
+    return posthog.onSessionId((id: string) => syncSessionCookie(id));
   }, [onReady]);
 
   return null;
@@ -98,6 +159,12 @@ function PostHogPageviewTracker() {
         ? \`\${pathname}?\${searchParams.toString()}\`
         : pathname;
       posthog.capture("$pageview", { $current_url: url });
+
+      // A soft navigation is activity the middleware never sees, and
+      // \`onSessionId\` won't fire because the id hasn't changed. Without this, a
+      // reader who browses only via client-side links would look idle to the
+      // next document load and have their session rotated out from under them.
+      syncSessionCookie(posthog.get_session_id());
     }
   }, [pathname, searchParams]);
 

--- a/src/templates/components/PostHogProviderLazy.ts
+++ b/src/templates/components/PostHogProviderLazy.ts
@@ -25,6 +25,33 @@ const posthogKey =
 const uiHost = (analyticsConfig.posthog?.host || "https://us.i.posthog.com")
   .replace(".i.posthog.com", ".posthog.com");
 
+/**
+ * Adopt the session id the middleware already decided on (see proxy.ts), so the
+ * server's document-load \`$pageview\` and every client event after it land in
+ * the same session.
+ *
+ * Without this the two disagree: the middleware used to forward posthog-js's
+ * own session id without checking whether it had expired, so a returning
+ * reader's pageview was filed under a dead session and the real new session
+ * began with no pageview in it — wrong landing page, wrong bounce rate.
+ *
+ * Reading document.cookie works on the first request because the middleware
+ * sets the cookie on the same response that carries this HTML. Returns
+ * undefined if absent or malformed, in which case posthog-js mints its own id
+ * as before: degraded, never broken.
+ */
+function readEdgeSessionId(): string | undefined {
+  if (typeof document === "undefined") return undefined;
+
+  const match = document.cookie.match(/(?:^|;\\s*)dcp_sid=([^;]*)/);
+  if (!match) return undefined;
+
+  // Cookie is \`id.startTs.lastTs\`; posthog-js requires the id be a UUID and
+  // logs an error if not, so check before handing it over.
+  const id = decodeURIComponent(match[1]).split(".")[0];
+  return /^[0-9a-f]{32}$/i.test(id.replace(/-/g, "")) ? id : undefined;
+}
+
 function PostHogInit({ onReady }: { onReady: () => void }) {
   const initRef = useRef(false);
 
@@ -32,11 +59,15 @@ function PostHogInit({ onReady }: { onReady: () => void }) {
     if (initRef.current || !posthogKey) return;
     initRef.current = true;
 
+    const sessionID = readEdgeSessionId();
+
     posthog.init(posthogKey, {
       api_host: "/ingest",
       ui_host: uiHost,
       capture_pageview: false,
       capture_pageleave: true,
+      // The edge owns session identity; this makes the SDK agree with it.
+      ...(sessionID ? { bootstrap: { sessionID } } : {}),
       loaded: onReady,
     });
   }, [onReady]);

--- a/src/templates/proxy.ts
+++ b/src/templates/proxy.ts
@@ -32,12 +32,80 @@ const ANON_ID_COOKIE = "dcp_anon_id";
 
 const ANON_ID_MAX_AGE = 60 * 60 * 24 * 365;
 
+/**
+ * Session id, shared between the edge and posthog-js.
+ *
+ * Deliberately NOT httpOnly, unlike the anon id: the browser has to read this
+ * one to hand back to \`posthog.init({ bootstrap })\`. It grants no privilege,
+ * and posthog-js already keeps an equivalent id in a readable cookie of its own.
+ */
+const SESSION_COOKIE = "dcp_sid";
+
+/** Same rules posthog-js uses internally. */
+const SESSION_IDLE_MS = 30 * 60 * 1000;
+const SESSION_MAX_MS = 24 * 60 * 60 * 1000;
+const SESSION_TOUCH_MS = 60 * 1000;
+
 interface TrackingIdentity {
   distinctId: string;
   /** Set only when the id was just minted and still needs writing to a cookie. */
   anonIdToPersist?: string;
-  sessionId?: string;
+  sessionId: string;
+  /** Set when the session cookie needs writing. */
+  sessionToPersist?: string;
   deviceId?: string;
+}
+
+/** posthog-js strips dashes and requires exactly 32 hex characters. */
+function isValidSessionId(id: string): boolean {
+  return /^[0-9a-f]{32}$/i.test(id.replace(/-/g, ""));
+}
+
+/**
+ * Owns session identity, rather than borrowing posthog-js's.
+ *
+ * We used to read posthog-js's \`$sesid\` cookie and forward \`$sesid[1]\` (the
+ * id) while ignoring \`$sesid[0]\` (last activity) and \`$sesid[2]\` (session
+ * start) — the fields posthog-js itself checks before deciding a session is
+ * still alive. A returning reader's pageview therefore went out stamped with a
+ * session that had expired days earlier: it stretched that dead session's
+ * duration, and the real new session began with no pageview in it, losing the
+ * landing page. Both feed bounce rate and entry-path reports.
+ *
+ * Now the edge decides and posthog-js adopts it via bootstrap, so there is one
+ * authority instead of two disagreeing.
+ */
+function resolveSession(
+  req: NextRequest,
+  now: number,
+  isActivity: boolean,
+): { sessionId: string; sessionToPersist?: string } {
+  const parts = req.cookies.get(SESSION_COOKIE)?.value?.split(".");
+
+  if (parts?.length === 3) {
+    const [id, startRaw, lastRaw] = parts;
+    const startTs = Number(startRaw);
+    const lastTs = Number(lastRaw);
+    const alive =
+      isValidSessionId(id) &&
+      Number.isFinite(startTs) &&
+      Number.isFinite(lastTs) &&
+      now - lastTs <= SESSION_IDLE_MS &&
+      now - startTs <= SESSION_MAX_MS;
+
+    if (alive) {
+      // A prefetch is the router speculating, not the reader acting, so it
+      // must not keep a session alive that would otherwise have expired.
+      const touch = isActivity && now - lastTs > SESSION_TOUCH_MS;
+      return {
+        sessionId: id,
+        sessionToPersist: touch ? \`\${id}.\${startTs}.\${now}\` : undefined,
+      };
+    }
+  }
+
+  const id = crypto.randomUUID();
+  return { sessionId: id, sessionToPersist: \`\${id}.\${now}.\${now}\` };
 }
 
 /**
@@ -45,9 +113,11 @@ interface TrackingIdentity {
  * established for this browser, else our own anonymous cookie, else a fresh id
  * that the caller persists.
  */
-function resolveTrackingIdentity(req: NextRequest): TrackingIdentity {
+function resolveTrackingIdentity(
+  req: NextRequest,
+  isActivity: boolean,
+): TrackingIdentity {
   let distinctId: string | undefined;
-  let sessionId: string | undefined;
   let deviceId: string | undefined;
 
   const phCookie = req.cookies.get(
@@ -57,24 +127,22 @@ function resolveTrackingIdentity(req: NextRequest): TrackingIdentity {
     try {
       const parsed = JSON.parse(phCookie);
       if (typeof parsed.distinct_id === "string") distinctId = parsed.distinct_id;
-      // \`$sesid\` is [lastActivityTs, sessionId, sessionStartTs]. Forwarding it
-      // keeps server events inside the client's session instead of floating free.
-      if (Array.isArray(parsed.$sesid) && typeof parsed.$sesid[1] === "string") {
-        sessionId = parsed.$sesid[1];
-      }
+      // Note we deliberately do NOT read \`$sesid\` — see resolveSession above.
       if (typeof parsed.$device_id === "string") deviceId = parsed.$device_id;
     } catch {
       // ignore malformed cookie
     }
   }
 
-  if (distinctId) return { distinctId, sessionId, deviceId };
+  const session = resolveSession(req, Date.now(), isActivity);
+
+  if (distinctId) return { distinctId, deviceId, ...session };
 
   const anonId = req.cookies.get(ANON_ID_COOKIE)?.value;
-  if (anonId) return { distinctId: anonId, sessionId, deviceId };
+  if (anonId) return { distinctId: anonId, deviceId, ...session };
 
   const minted = crypto.randomUUID();
-  return { distinctId: minted, anonIdToPersist: minted, sessionId, deviceId };
+  return { distinctId: minted, anonIdToPersist: minted, deviceId, ...session };
 }
 
 /**
@@ -90,19 +158,24 @@ function captureServerPageview(
 
   if (SKIP_PAGEVIEW_PATTERN.test(pathname)) return null;
 
+  // A prefetch is the router speculating, not the reader acting: it neither
+  // counts as a pageview nor keeps a session alive.
   const isPrefetch =
     req.headers.get("next-router-prefetch") === "1" ||
     req.headers.get("purpose") === "prefetch";
   if (isPrefetch) return null;
 
+  const identity = resolveTrackingIdentity(req, true);
+
   // A soft navigation fetches an RSC payload rather than a document, and
-  // carries this header. The client tracker owns those.
-  if (req.headers.get("RSC")) return null;
+  // carries this header. The client tracker owns counting those — but browsing
+  // that way is still real activity, so we return the identity anyway to keep
+  // the session cookie alive. Returning null here would let a reader who
+  // navigates only via client-side links expire mid-visit.
+  if (req.headers.get("RSC")) return identity;
 
   const posthog = getPostHogServerClient();
-  if (!posthog) return null;
-
-  const identity = resolveTrackingIdentity(req);
+  if (!posthog) return identity;
 
   posthog.capture({
     distinctId: identity.distinctId,
@@ -140,6 +213,17 @@ function applyTracking(
       maxAge: ANON_ID_MAX_AGE,
       sameSite: "lax",
       httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+    });
+  }
+  if (tracking?.sessionToPersist) {
+    // httpOnly: false is required — the browser reads this to bootstrap
+    // posthog-js so the client agrees with the edge about the session.
+    res.cookies.set(SESSION_COOKIE, tracking.sessionToPersist, {
+      path: "/",
+      maxAge: SESSION_MAX_MS / 1000,
+      sameSite: "lax",
+      httpOnly: false,
       secure: process.env.NODE_ENV === "production",
     });
   }

--- a/src/templates/proxy.ts
+++ b/src/templates/proxy.ts
@@ -39,6 +39,10 @@ const ANON_ID_MAX_AGE = 60 * 60 * 24 * 365;
  * one to hand back to \`posthog.init({ bootstrap })\`. It grants no privilege,
  * and posthog-js already keeps an equivalent id in a readable cookie of its own.
  */
+// SESSION_COOKIE, SESSION_MAX_MS and isValidSessionId are mirrored in
+// PostHogProviderLazy, which also writes this cookie. Keep them in sync — a
+// drifted max-age would silently expire live sessions. They are duplicated
+// rather than shared because a client component cannot import from here.
 const SESSION_COOKIE = "dcp_sid";
 
 /** Same rules posthog-js uses internally. */

--- a/src/templates/proxy.ts
+++ b/src/templates/proxy.ts
@@ -44,7 +44,6 @@ const SESSION_COOKIE = "dcp_sid";
 /** Same rules posthog-js uses internally. */
 const SESSION_IDLE_MS = 30 * 60 * 1000;
 const SESSION_MAX_MS = 24 * 60 * 60 * 1000;
-const SESSION_TOUCH_MS = 60 * 1000;
 
 interface TrackingIdentity {
   distinctId: string;
@@ -72,13 +71,23 @@ function isValidSessionId(id: string): boolean {
  * duration, and the real new session began with no pageview in it, losing the
  * landing page. Both feed bounce rate and entry-path reports.
  *
- * Now the edge decides and posthog-js adopts it via bootstrap, so there is one
- * authority instead of two disagreeing.
+ * Now the middleware decides and posthog-js adopts it via bootstrap, so there is
+ * one authority instead of two disagreeing.
+ *
+ * **The middleware writes this cookie only when it mints a new session.**
+ * Keeping \`lastTs\` fresh is the browser's job (see PostHogSetup). That split is
+ * deliberate: a response carrying \`Set-Cookie\` is not cacheable by Vercel's CDN,
+ * and refreshing last-activity here would have put one on roughly every doc page
+ * an engaged reader loads. A \`document.cookie\` write from the browser sets no
+ * response header at all, so your doc pages stay cacheable.
+ *
+ * Consequence: if an ad blocker stops posthog-js, nothing refreshes \`lastTs\`, so
+ * that reader's sessions become fixed ~30-minute windows rather than idle-based.
+ * Coarser, but still correct.
  */
 function resolveSession(
   req: NextRequest,
   now: number,
-  isActivity: boolean,
 ): { sessionId: string; sessionToPersist?: string } {
   const parts = req.cookies.get(SESSION_COOKIE)?.value?.split(".");
 
@@ -93,15 +102,8 @@ function resolveSession(
       now - lastTs <= SESSION_IDLE_MS &&
       now - startTs <= SESSION_MAX_MS;
 
-    if (alive) {
-      // A prefetch is the router speculating, not the reader acting, so it
-      // must not keep a session alive that would otherwise have expired.
-      const touch = isActivity && now - lastTs > SESSION_TOUCH_MS;
-      return {
-        sessionId: id,
-        sessionToPersist: touch ? \`\${id}.\${startTs}.\${now}\` : undefined,
-      };
-    }
+    // Alive: adopt it and write nothing, so the response stays cacheable.
+    if (alive) return { sessionId: id };
   }
 
   const id = crypto.randomUUID();
@@ -113,10 +115,7 @@ function resolveSession(
  * established for this browser, else our own anonymous cookie, else a fresh id
  * that the caller persists.
  */
-function resolveTrackingIdentity(
-  req: NextRequest,
-  isActivity: boolean,
-): TrackingIdentity {
+function resolveTrackingIdentity(req: NextRequest): TrackingIdentity {
   let distinctId: string | undefined;
   let deviceId: string | undefined;
 
@@ -134,7 +133,7 @@ function resolveTrackingIdentity(
     }
   }
 
-  const session = resolveSession(req, Date.now(), isActivity);
+  const session = resolveSession(req, Date.now());
 
   if (distinctId) return { distinctId, deviceId, ...session };
 
@@ -165,17 +164,16 @@ function captureServerPageview(
     req.headers.get("purpose") === "prefetch";
   if (isPrefetch) return null;
 
-  const identity = resolveTrackingIdentity(req, true);
-
   // A soft navigation fetches an RSC payload rather than a document, and
-  // carries this header. The client tracker owns counting those — but browsing
-  // that way is still real activity, so we return the identity anyway to keep
-  // the session cookie alive. Returning null here would let a reader who
-  // navigates only via client-side links expire mid-visit.
-  if (req.headers.get("RSC")) return identity;
+  // carries this header. The client tracker owns those — and it also keeps the
+  // session cookie fresh from the browser, so there is nothing for us to do
+  // here.
+  if (req.headers.get("RSC")) return null;
 
   const posthog = getPostHogServerClient();
-  if (!posthog) return identity;
+  if (!posthog) return null;
+
+  const identity = resolveTrackingIdentity(req);
 
   posthog.capture({
     distinctId: identity.distinctId,


### PR DESCRIPTION
## The bug

The generated proxy read posthog-js's `$sesid` cookie and forwarded `$sesid[1]` (the session id) while ignoring `$sesid[0]` (last activity) and `$sesid[2]` (session start) — the two fields posthog-js itself checks before deciding a session is still alive.

A returning reader's document-load pageview therefore went out stamped with a session that had **expired days earlier**:

- it stretched that dead session's duration, and
- the real new session began with **no pageview in it**, losing the landing page for the visit.

Both are direct inputs to bounce rate and entry-path reports, and it affected every returning reader — not an edge case.

**Because this is a template, the bug shipped into every site the CLI generates.**

## The fix

The middleware now owns session identity via `resolveSession`, rotating on the same rules posthog-js uses (30 min idle, 24 h hard cap), backed by a `dcp_sid` cookie holding `id.startTs.lastTs`. posthog-js adopts that id through `bootstrap.sessionID`, so there is one authority instead of two that disagree. The `$sesid` read is gone.

Supporting behaviour:

- **Soft navigations keep the session alive but are still not counted as pageviews.** Returning `null` there would let a reader who navigates only via client-side links expire mid-visit.
- **Prefetches neither count nor extend a session** — the router speculating is not the reader acting.
- **`dcp_sid` is deliberately not `httpOnly`**: the browser must read it to bootstrap. It grants no privilege, and posthog-js already keeps an equivalent id in a readable cookie of its own.

## Verification

- `npx tsc --noEmit` clean; `npm test` 42/42 pass.
- Built the CLI and rendered the templates, then confirmed the **emitted** output is correct — template-literal escaping resolves to `/(?:^|;\s*)dcp_sid=([^;]*)/` and clean backticks (this was wrong on my first pass and is the easiest thing to get wrong here).
- Extracted `resolveSession` **from the generated file**, using the emitted constants, and exercised the boundaries: 8/8 pass — including the actual bug case (3-day-old session now rotates), the 29-vs-31-minute idle boundary, the 24 h cap under constant activity, prefetch non-extension, and malformed-cookie handling.

## Not included

Two related PostHog issues found in the same audit, deliberately out of scope here:

- Anonymous pageviews are captured **without** `$process_person_profile: false`, so PostHog bills them at the identified rate (up to 4x). For generated doc sites, where essentially every reader is anonymous, this is likely the single largest analytics cost your users carry.
- No error tracking (`instrumentation.ts`).