### PR TITLE
feat: generate subscribable RSS feeds for Update changelog pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - **Auto-generated navigation** - sidebar built from frontmatter (`category`, `order`)
 - **Sections** - organize docs into tabbed sections via frontmatter or `sections.json`
 - **API reference** - point at an OpenAPI spec to generate interactive endpoint pages with a live playground
+- **Subscribable changelogs** - pages using the `Update` component publish an RSS feed at `{page-url}/rss.xml`
 - **Theming** - dark/light mode with customizable theme via `theme.json`
 - **AI chat assistant** - built-in RAG-powered chat (OpenAI, Anthropic, or Google)
 - **MCP server** - exposes `search_docs`, `get_doc`, and `list_docs` tools for AI agents

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -308,6 +308,14 @@ describe.skipIf(!fs.pathExistsSync(distEntry))(
             ),
           ),
         ).toBe(true);
+        // The starting docs ship an <Update> page with `rss: true`, so the
+        // format check also covers the generated feed route and the RSS-button
+        // page shape.
+        expect(
+          await fs.pathExists(
+            path.join(outDir, "app", "(site)", "update", "rss.xml", "route.ts"),
+          ),
+        ).toBe(true);
 
         // Mirror `prettier --write .` with a non-mutating `--check`, honoring
         // the generated .prettierrc + .prettierignore in the app directory.

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,10 +34,12 @@ import {
   generateRuntimeOnlyMetadataBlock,
   generateJsonLdScript,
 } from "./lib/metadata.js";
+import { parseUpdateBlocks } from "./lib/rss.js";
 import { nextConfigTemplate } from "./templates/next.config.js";
 import { pnpmWorkspaceTemplate } from "./templates/pnpmWorkspace.js";
 import { proxyTemplate } from "./templates/proxy.js";
 import { robotsTemplate } from "./templates/app/robots.js";
+import { rssRouteTemplate } from "./templates/app/rssRoute.js";
 import { sitemapTemplate, type SitemapEntry } from "./templates/app/sitemap.js";
 import { llmsIndexTemplate } from "./templates/llms/llmsIndex.js";
 import {
@@ -1268,6 +1270,14 @@ export default function SectionIndex() {
     const fm = mdxFile.frontmatter;
     const apiOperation = options?.apiOperation;
 
+    // Pages containing <Update> blocks publish a subscribable changelog: an
+    // RSS feed at {page-url}/rss.xml. Synthetic OpenAPI pages never contain
+    // Update blocks, so skip the parse for them.
+    const isSynthetic = mdxFile.path.startsWith("@openapi/");
+    const updates = isSynthetic ? [] : parseUpdateBlocks(mdxFile.content);
+    const hasFeed = updates.length > 0;
+    const feedPath = `/${mdxFile.slug}/rss.xml`;
+
     const metadataBlock = generateMetadataBlock({
       title: fm.title,
       titleFallback: "Generated with Doccupine",
@@ -1277,6 +1287,7 @@ export default function SectionIndex() {
       icon: fm.icon,
       image: fm.image,
       canonicalPath: mdxFile.slug,
+      rssPath: hasFeed ? feedPath : undefined,
     });
 
     const jsonLd = generateJsonLdScript({
@@ -1323,11 +1334,26 @@ export default function SectionIndex() {
     // diagrams (which endpoint docs never contain), and its long `@openapi/...`
     // value would push the opening tag past 80 cols and make Prettier rewrap it.
     const sourcePathLiteral = JSON.stringify(mdxFile.path);
+    // `rss: true` frontmatter opts the page into an RSS button in the action
+    // bar (only when a feed actually exists). The playground branch keeps its
+    // fixed JSX shape - a feed on an inline-playground page stays reachable
+    // via autodiscovery. The buttoned form usually exceeds the 80-col print
+    // width, so pre-wrap it in the shape Prettier produces (attributes on
+    // their own lines) relative to its 6-space insertion indent.
+    const showRssButton = hasFeed && fm.rss === true && !apiOperation;
+    const docsAttrs = [
+      `content={content}`,
+      `sourcePath={${sourcePathLiteral}}`,
+      ...(showRssButton ? [`rssHref={${JSON.stringify(feedPath)}}`] : []),
+    ];
+    const inlineDocs = `<Docs ${docsAttrs.join(" ")} />`;
     const docsElement = apiOperation
       ? `<Docs content={content}>
         <ApiPlayground operation={operation} />
       </Docs>`
-      : `<Docs content={content} sourcePath={${sourcePathLiteral}} />`;
+      : inlineDocs.length + 6 <= 80
+        ? inlineDocs
+        : `<Docs\n${docsAttrs.map((attr) => `        ${attr}`).join("\n")}\n      />`;
 
     const pageContent = `import { Metadata } from "next";
 import { Docs } from "@/components/Docs";
@@ -1364,6 +1390,35 @@ export default function Page() {
     );
     await fs.ensureDir(path.dirname(pagePath));
     await fs.writeFile(pagePath, pageContent, "utf8");
+
+    // The feed route lives inside the page's directory, so a deleted page
+    // takes its feed along (handleFileDelete removes the whole dir) and the
+    // else-branch prunes the route when a regenerated page no longer has
+    // Update blocks. Cross-run staleness is covered by the app/ wipe in
+    // createNextJSStructure.
+    if (!isSynthetic) {
+      const rssDir = path.join(path.dirname(pagePath), "rss.xml");
+      if (hasFeed) {
+        await fs.ensureDir(rssDir);
+        await fs.writeFile(
+          path.join(rssDir, "route.ts"),
+          rssRouteTemplate({
+            pagePath: mdxFile.slug,
+            title: typeof fm.title === "string" ? fm.title : null,
+            description:
+              typeof fm.description === "string" ? fm.description : null,
+            items: updates.map((update) => ({
+              title: update.label,
+              anchor: update.anchor,
+              description: update.description,
+            })),
+          }),
+          "utf8",
+        );
+      } else {
+        await fs.remove(rssDir);
+      }
+    }
   }
 
   /** Parses the configured OpenAPI spec(s) into the shared registry. */

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -131,6 +131,11 @@ export interface MetadataOptions {
    * Resolves against `metadataBase` defined in the root layout.
    */
   canonicalPath?: string;
+  /**
+   * Path of this page's RSS feed, e.g. "/update/rss.xml". Emitted as an
+   * `alternates.types` entry so feed readers can autodiscover the feed.
+   */
+  rssPath?: string;
 }
 
 function buildFieldExpression(
@@ -159,12 +164,26 @@ function buildTitleExpression(opts: MetadataOptions): string {
   return `${prefix} ${title}`;
 }
 
-function buildCanonicalLine(canonicalPath: string | undefined): string {
+function buildAlternatesBlock(
+  canonicalPath: string | undefined,
+  rssPath: string | undefined,
+): string {
   if (canonicalPath === undefined) return "";
   const safePath = canonicalPath.replace(/^\/+/, "");
-  // Relative path resolves against `metadataBase` set in the root layout.
+  // Relative paths resolve against `metadataBase` set in the root layout.
   // Empty string means the homepage canonical equals the base URL itself.
-  return `\n  alternates: { canonical: ${JSON.stringify("/" + safePath)} },`;
+  const canonical = JSON.stringify("/" + safePath);
+  if (!rssPath) return `\n  alternates: { canonical: ${canonical} },`;
+  const rss = JSON.stringify(rssPath);
+  // Prettier preserves an object literal that already breaks after "{", so
+  // the expanded form is stable; only the inner `types` line can overflow
+  // the 80-col print width (long slugs) and needs the pre-wrap check.
+  const typesInline = `    types: { "application/rss+xml": ${rss} },`;
+  const typesLines =
+    typesInline.length <= 80
+      ? typesInline
+      : `    types: {\n      "application/rss+xml": ${rss},\n    },`;
+  return `\n  alternates: {\n    canonical: ${canonical},\n${typesLines}\n  },`;
 }
 
 export function generateMetadataBlock(opts: MetadataOptions): string {
@@ -176,7 +195,7 @@ export function generateMetadataBlock(opts: MetadataOptions): string {
   );
   const icon = buildFieldExpression(opts.icon, "icon", DEFAULT_FAVICON);
   const image = buildFieldExpression(opts.image, "image", DEFAULT_OG_IMAGE);
-  const canonical = buildCanonicalLine(opts.canonicalPath);
+  const canonical = buildAlternatesBlock(opts.canonicalPath, opts.rssPath);
 
   return `export const metadata: Metadata = {
   title: \`${title}\`,

--- a/src/lib/rss.test.ts
+++ b/src/lib/rss.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from "vitest";
+import matter from "gray-matter";
+import {
+  slugify,
+  createSlugger,
+  parseUpdateBlocks,
+  toRssMarkdown,
+} from "./rss.js";
+import { slugTemplate } from "../templates/components/layout/Slug.js";
+import { docsTemplate } from "../templates/components/Docs.js";
+import { updateMdxTemplate } from "../templates/mdx/update.mdx.js";
+import { rssRouteTemplate } from "../templates/app/rssRoute.js";
+
+describe("slugify", () => {
+  it("lowercases and hyphenates whitespace", () => {
+    expect(slugify("Key Additions")).toBe("key-additions");
+  });
+
+  it("strips symbols including dots (version labels)", () => {
+    expect(slugify("v0.0.1")).toBe("v001");
+    expect(slugify("v2.0 (beta)")).toBe("v20-beta");
+  });
+
+  it("drops non-word characters like accents", () => {
+    expect(slugify("café")).toBe("caf");
+  });
+
+  it("handles empty and nullish input", () => {
+    expect(slugify("")).toBe("");
+  });
+});
+
+describe("createSlugger", () => {
+  it("de-duplicates with occurrence suffixes", () => {
+    const slug = createSlugger();
+    expect(slug("Setup")).toBe("setup");
+    expect(slug("Setup")).toBe("setup-1");
+    expect(slug("Setup")).toBe("setup-2");
+    expect(slug("Other")).toBe("other");
+  });
+});
+
+// The CLI ports must stay byte-identical to the generated app's slugger and
+// document walk, or feed anchors stop resolving. These guards fail when the
+// templates drift so the port (and these tests) get updated in lockstep.
+describe("template parity drift-guards", () => {
+  it("Slug.ts template still matches the CLI slugify port", () => {
+    expect(slugTemplate).toContain('.replace(/[^\\w\\s-]/g, "")');
+    expect(slugTemplate).toContain('.replace(/\\s+/g, "-")');
+    expect(slugTemplate).toContain(".toLowerCase()");
+    expect(slugTemplate).toContain(".trim();");
+    expect(slugTemplate).toContain("const count = seen.get(base) ?? 0;");
+    expect(slugTemplate).toContain("seen.set(base, count + 1);");
+    expect(slugTemplate).toContain("count === 0 ? base : `${base}-${count}`");
+  });
+
+  it("Docs.ts extractHeadings still matches the CLI walk", () => {
+    expect(docsTemplate).toContain('content.replace(/```[\\s\\S]*?```/g, "")');
+    expect(docsTemplate).toContain("/^(#{1,6})\\s+(.+)$/gm");
+    expect(docsTemplate).toContain(
+      "/<Update\\b[^>]*?\\blabel=[\"']([^\"']+)[\"'][^>]*>/g",
+    );
+    expect(docsTemplate).toContain(".sort((a, b) => a.position - b.position)");
+  });
+});
+
+describe("parseUpdateBlocks", () => {
+  it("extracts label, anchor, and markdown description", () => {
+    const items = parseUpdateBlocks(
+      '<Update label="v1.0" description="First">\n  Fixed a bug.\n</Update>',
+    );
+    expect(items).toEqual([
+      { label: "v1.0", anchor: "v10", description: "Fixed a bug." },
+    ]);
+  });
+
+  it("shares the slugger with headings (dedup interplay)", () => {
+    const mdx = '## Setup\n\n<Update label="Setup">\n  Text.\n</Update>';
+    expect(parseUpdateBlocks(mdx)[0].anchor).toBe("setup-1");
+  });
+
+  it("de-duplicates repeated labels", () => {
+    const mdx =
+      '<Update label="v1.0">\n  A.\n</Update>\n\n<Update label="v1.0">\n  B.\n</Update>';
+    const items = parseUpdateBlocks(mdx);
+    expect(items.map((i) => i.anchor)).toEqual(["v10", "v10-1"]);
+  });
+
+  it("ignores Update examples inside fenced code blocks", () => {
+    const mdx =
+      '<Update label="Real">\n  Yes.\n</Update>\n\n```html\n<Update label="Example">\n  No.\n</Update>\n```';
+    const items = parseUpdateBlocks(mdx);
+    expect(items.map((i) => i.label)).toEqual(["Real"]);
+  });
+
+  it("prefers the rss attribute over children (both quote styles)", () => {
+    const double = parseUpdateBlocks(
+      '<Update label="v1" rss="Feed text.">\n  Page text.\n</Update>',
+    );
+    expect(double[0].description).toBe("Feed text.");
+    const single = parseUpdateBlocks(
+      "<Update label='v1' rss='Feed text.'>\n  Page text.\n</Update>",
+    );
+    expect(single[0].description).toBe("Feed text.");
+  });
+
+  it("handles self-closing blocks", () => {
+    const items = parseUpdateBlocks('<Update label="v1" rss="Only feed." />');
+    expect(items).toEqual([
+      { label: "v1", anchor: "v1", description: "Only feed." },
+    ]);
+  });
+
+  it("matches multi-line open tags", () => {
+    const mdx = '<Update\n  label="v1"\n  description="d"\n>\n  Hi.\n</Update>';
+    expect(parseUpdateBlocks(mdx)).toEqual([
+      { label: "v1", anchor: "v1", description: "Hi." },
+    ]);
+  });
+
+  it("runs an unclosed block to the end of the document", () => {
+    const items = parseUpdateBlocks('<Update label="v1">\n  Tail text.');
+    expect(items[0].description).toBe("Tail text.");
+  });
+
+  it("tracks depth for nested blocks", () => {
+    const mdx =
+      '<Update label="Outer">\n  Before.\n  <Update label="Inner">\n    Within.\n  </Update>\n  After.\n</Update>';
+    const items = parseUpdateBlocks(mdx);
+    expect(items.map((i) => i.label)).toEqual(["Outer", "Inner"]);
+    // The outer entry spans past the inner close tag; the inner block's text
+    // survives with its relative indentation once the tags are removed.
+    expect(items[0].description).toBe("Before.\n\n  Within.\n\nAfter.");
+    expect(items[1].description).toBe("Within.");
+  });
+
+  it("preserves document order", () => {
+    const mdx =
+      '<Update label="B">\n  b\n</Update>\n\n<Update label="A">\n  a\n</Update>';
+    expect(parseUpdateBlocks(mdx).map((i) => i.label)).toEqual(["B", "A"]);
+  });
+
+  it("returns no items for pages without Update blocks", () => {
+    expect(parseUpdateBlocks("# Just a page\n\nText.")).toEqual([]);
+  });
+
+  it("extracts the expected feed from the shipped update.mdx sample", () => {
+    const { content } = matter(updateMdxTemplate);
+    const items = parseUpdateBlocks(content);
+    expect(items.map((i) => i.label)).toContain("v0.0.1");
+    const first = items.find((i) => i.label === "v0.0.1")!;
+    expect(first.anchor).toBe("v001");
+    expect(first.description).toContain("Fully responsive layout");
+    expect(first.description).not.toContain("<");
+  });
+});
+
+describe("toRssMarkdown", () => {
+  it("removes component tags but keeps their text children", () => {
+    expect(toRssMarkdown("<Note>Heads up.</Note>")).toBe("Heads up.");
+  });
+
+  it("removes HTML elements and comments", () => {
+    expect(toRssMarkdown('<div class="x">Hi</div> <!-- note -->')).toBe("Hi");
+  });
+
+  it("collapses images to their alt text", () => {
+    expect(toRssMarkdown("![Demo Image](https://x.test/a.png)")).toBe(
+      "Demo Image",
+    );
+  });
+
+  it("unwraps inline code and drops fenced code", () => {
+    expect(toRssMarkdown("Use `npm i`.\n\n```bash\nnpm i\n```")).toBe(
+      "Use npm i.",
+    );
+  });
+
+  it("keeps markdown links and autolinks", () => {
+    expect(toRssMarkdown("[docs](https://x.test) and <https://x.test>")).toBe(
+      "[docs](https://x.test) and <https://x.test>",
+    );
+  });
+
+  it("dedents indented children and collapses blank runs", () => {
+    const inner = "\n  ## Notes\n\n\n\n  - one\n  - two\n";
+    expect(toRssMarkdown(inner)).toBe("## Notes\n\n- one\n- two");
+  });
+});
+
+describe("rssRouteTemplate", () => {
+  const feed = {
+    pagePath: "update",
+    title: "Update",
+    description: "Changelog",
+    items: [{ title: "v0.0.1", anchor: "v001", description: "Notes." }],
+  };
+
+  it("emits a force-static RSS route", () => {
+    const out = rssRouteTemplate(feed);
+    expect(out).toContain('export const dynamic = "force-static";');
+    expect(out).toContain("export const revalidate = false;");
+    expect(out).toContain("application/rss+xml; charset=utf-8");
+    expect(out).toContain("import { buildRssFeed, type RssFeedData }");
+  });
+
+  it("pre-wraps the embedded feed (always exceeds the print width)", () => {
+    // Even an empty feed overflows 80 cols once the JSON.parse prefix is
+    // added, so every emitted route uses the wrapped argument shape.
+    const minimal = rssRouteTemplate({
+      pagePath: "u",
+      title: null,
+      description: null,
+      items: [],
+    });
+    expect(minimal).toContain("JSON.parse(\n  '");
+    expect(minimal).toContain("',\n);");
+    const full = rssRouteTemplate(feed);
+    expect(full).toContain("JSON.parse(\n  '");
+    expect(full).toContain("',\n);");
+  });
+});

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -1,0 +1,164 @@
+// Feed extraction for subscribable changelogs: pages that contain <Update>
+// blocks publish an RSS feed at {page-url}/rss.xml.
+//
+// Anchor parity is the load-bearing constraint here. Feed entry links are
+// `{pageUrl}#{anchor}`, and the anchor must byte-match the id the generated
+// app assigns: one shared slugger walks the fenced-code-stripped document
+// collecting markdown headings AND <Update label> open tags in byte order
+// (components/Docs.tsx `extractHeadings` + components/MDXComponents.tsx).
+// `slugify`/`createSlugger` below are byte-exact ports of the generated
+// app's components/layout/Slug.ts, and `parseUpdateBlocks` replays that
+// exact walk - headings consume slugger slots too, so an `## Setup` before
+// `<Update label="Setup">` pushes the entry's anchor to "setup-1".
+// rss.test.ts guards both ports against template drift.
+
+export function slugify(text: string): string {
+  return (text ?? "")
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .trim();
+}
+
+export type Slugger = (text: string) => string;
+
+export function createSlugger(): Slugger {
+  const seen = new Map<string, number>();
+  return (text: string) => {
+    const base = slugify(text);
+    const count = seen.get(base) ?? 0;
+    seen.set(base, count + 1);
+    return count === 0 ? base : `${base}-${count}`;
+  };
+}
+
+export interface UpdateFeedItem {
+  /** The Update's `label` attribute; doubles as the feed entry title. */
+  label: string;
+  /** Anchor id the generated app assigns this entry (see parity note above). */
+  anchor: string;
+  /**
+   * Feed entry text: the `rss` attribute when present, otherwise the block's
+   * children reduced to pure Markdown (components, code, and HTML removed).
+   */
+  description: string;
+}
+
+export function parseUpdateBlocks(mdx: string): UpdateFeedItem[] {
+  // Fenced code is stripped before any matching, mirroring extractHeadings:
+  // an <Update> example inside a fence is not an entry, and positions below
+  // are measured in the stripped string on both sides of the parity contract.
+  const content = mdx.replace(/```[\s\S]*?```/g, "");
+
+  interface Entry {
+    kind: "heading" | "update";
+    text: string;
+    position: number;
+    tag: string;
+    tagEnd: number;
+  }
+  const entries: Entry[] = [];
+  let match: RegExpExecArray | null;
+
+  const headingRegex = /^(#{1,6})\s+(.+)$/gm;
+  while ((match = headingRegex.exec(content)) !== null) {
+    entries.push({
+      kind: "heading",
+      text: match[2].trim(),
+      position: match.index,
+      tag: "",
+      tagEnd: 0,
+    });
+  }
+
+  // [^>] spans newlines, so multi-line open tags match - same as the app.
+  const updateRegex = /<Update\b[^>]*?\blabel=["']([^"']+)["'][^>]*>/g;
+  while ((match = updateRegex.exec(content)) !== null) {
+    entries.push({
+      kind: "update",
+      text: match[1].trim(),
+      position: match.index,
+      tag: match[0],
+      tagEnd: match.index + match[0].length,
+    });
+  }
+
+  entries.sort((a, b) => a.position - b.position);
+
+  const slug = createSlugger();
+  const items: UpdateFeedItem[] = [];
+  for (const entry of entries) {
+    const anchor = slug(entry.text);
+    if (entry.kind !== "update") continue;
+    const rssAttr = /\brss=["']([^"']*)["']/.exec(entry.tag)?.[1];
+    const inner = entry.tag.endsWith("/>")
+      ? ""
+      : extractInner(content, entry.tagEnd);
+    items.push({
+      label: entry.text,
+      anchor,
+      description:
+        rssAttr !== undefined ? rssAttr.trim() : toRssMarkdown(inner),
+    });
+  }
+  return items;
+}
+
+/**
+ * Slice out an Update block's children: scan from the end of its open tag to
+ * the matching close tag, tracking depth so nested <Update> blocks close
+ * correctly. An unclosed block runs to the end of the document (the renderer
+ * swallows the rest of the page in that case too).
+ */
+function extractInner(content: string, from: number): string {
+  const token = /<Update\b[^>]*?>|<\/Update\s*>/g;
+  token.lastIndex = from;
+  let depth = 1;
+  let match: RegExpExecArray | null;
+  while ((match = token.exec(content)) !== null) {
+    if (match[0].startsWith("</")) {
+      depth -= 1;
+      if (depth === 0) return content.slice(from, match.index);
+    } else if (!match[0].endsWith("/>")) {
+      depth += 1;
+    }
+  }
+  return content.slice(from);
+}
+
+/**
+ * Reduce an Update block's children to pure Markdown for feed readers:
+ * components, code, and HTML are removed (tag children text survives),
+ * images collapse to their alt text, inline code keeps its text. Markdown
+ * inline syntax (emphasis, links, lists, headings) passes through, including
+ * autolinks - `<https://...>` never matches the tag pattern because a `:`
+ * follows the leading word characters.
+ */
+export function toRssMarkdown(inner: string): string {
+  const stripped = inner
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .replace(/<\/?[A-Za-z][a-zA-Z0-9]*(?:\s[^>]*)?\/?>/g, "")
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/`([^`]*)`/g, "$1");
+  return dedent(stripped)
+    .replace(/[ \t]+$/gm, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+/**
+ * Update children are conventionally indented under the open tag; strip the
+ * common leading indentation so lists and headings arrive at column 0.
+ */
+function dedent(text: string): string {
+  const lines = text.split("\n");
+  let minIndent = Infinity;
+  for (const line of lines) {
+    if (line.trim() === "") continue;
+    const indent = /^ */.exec(line)![0].length;
+    if (indent < minIndent) minIndent = indent;
+  }
+  if (!Number.isFinite(minIndent) || minIndent === 0) return text;
+  return lines.map((line) => line.slice(minIndent)).join("\n");
+}

--- a/src/lib/structures.ts
+++ b/src/lib/structures.ts
@@ -77,6 +77,7 @@ import { llmTypesTemplate } from "../templates/services/llm/types.js";
 import { buildDocsIndexScriptTemplate } from "../templates/scripts/build-docs-index.js";
 
 import { posthogServerTemplate } from "../templates/lib/posthog.js";
+import { rssLibTemplate } from "../templates/lib/rss.js";
 import { siteGateTemplate } from "../templates/lib/siteGate.js";
 
 import { styledDTemplate } from "../templates/types/styled.js";
@@ -189,6 +190,7 @@ export const appStructure: Record<string, string> = {
   "types/openapi.ts": openapiTypesTemplate,
 
   "lib/posthog.ts": posthogServerTemplate,
+  "lib/rss.ts": rssLibTemplate,
   "lib/siteGate.ts": siteGateTemplate,
 
   "utils/branding.ts": brandingTemplate,

--- a/src/templates/app/rssRoute.ts
+++ b/src/templates/app/rssRoute.ts
@@ -1,0 +1,40 @@
+import { toJsStringLiteral } from "../../lib/utils.js";
+
+export interface RssRouteData {
+  pagePath: string;
+  title: string | null;
+  description: string | null;
+  items: { title: string; anchor: string; description: string }[];
+}
+
+export const rssRouteTemplate = (feed: RssRouteData): string => {
+  // JSON.stringify + toJsStringLiteral is total escaping for arbitrary entry
+  // strings (quotes, newlines, backticks), and JSON.parse at load undoes it -
+  // the same trick as the OpenAPI operation embed in generatePageFromMDX.
+  // The call always overflows 80 cols, so emit it pre-wrapped in the shape
+  // Prettier produces (argument on its own line with a trailing comma) to
+  // keep generated routes format-stable without running a formatter.
+  const arg = toJsStringLiteral(JSON.stringify(feed));
+  const inline = `const FEED: RssFeedData = JSON.parse(${arg});`;
+  const decl =
+    inline.length <= 80
+      ? inline
+      : `const FEED: RssFeedData = JSON.parse(\n  ${arg},\n);`;
+
+  return `import { buildRssFeed, type RssFeedData } from "@/lib/rss";
+
+// Feed data is extracted from this page's MDX at generation time.
+${decl}
+
+// The feed derives entirely from generation-time content, so it renders once
+// at build and serves from the static cache like the page it belongs to.
+export const dynamic = "force-static";
+export const revalidate = false;
+
+export function GET(): Response {
+  return new Response(buildRssFeed(FEED), {
+    headers: { "Content-Type": "application/rss+xml; charset=utf-8" },
+  });
+}
+`;
+};

--- a/src/templates/components/Docs.ts
+++ b/src/templates/components/Docs.ts
@@ -18,6 +18,9 @@ import { rehypeCodeMeta } from "@/utils/rehypeCodeMeta";
 interface DocsProps {
   content: string;
   sourcePath?: string;
+  // Path of this page's RSS feed; when set, the action bar shows an RSS
+  // button linking to it.
+  rssHref?: string;
   // Extra content rendered inside the markdown column, after the MDX body.
   // Used to place generated widgets (e.g. the API playground) inside the docs
   // content area rather than outside its layout.
@@ -85,7 +88,7 @@ function MissingComponent({
   );
 }
 
-function Docs({ content, sourcePath, children }: DocsProps) {
+function Docs({ content, sourcePath, rssHref, children }: DocsProps) {
   const headings = extractHeadings(content);
   const components = useMDXComponents({
     pre: createMermaidPre(sourcePath),
@@ -109,7 +112,7 @@ function Docs({ content, sourcePath, children }: DocsProps) {
   return (
     <>
       <DocsContainer>
-        <ActionBar content={content}>
+        <ActionBar content={content} rssHref={rssHref}>
           <Flex $gap={20}>
             <StyledMarkdownContainer>
               {children}

--- a/src/templates/components/layout/ActionBar.ts
+++ b/src/templates/components/layout/ActionBar.ts
@@ -14,6 +14,9 @@ import { StyledSmallButton } from "@/components/layout/SharedStyled";
 interface ActionBarProps {
   children: React.ReactNode;
   content: string;
+  // When set, an RSS button linking to this page's feed renders next to the
+  // copy pill.
+  rssHref?: string;
 }
 
 const StyledActionBar = styled.div<{
@@ -52,6 +55,26 @@ const StyledCopyButton = styled(StyledSmallButton)<{
   & svg.lucide {
     color: \${({ theme, $copied }) =>
       $copied ? theme.colors.success : theme.colors.primary};
+  }
+\`;
+
+// StyledSmallButton carries a -6px right margin for edge alignment; inside
+// the pill group that would eat into the gap, so it is neutralized here.
+const StyledActionBarGroup = styled.div\`
+  display: flex;
+  gap: 12px;
+
+  & > * {
+    margin-right: 0;
+  }
+\`;
+
+const StyledRssLink = styled(StyledSmallButton)<{ theme: Theme }>\`
+  text-decoration: none;
+  color: \${({ theme }) => theme.colors.primary};
+
+  & svg.lucide {
+    color: \${({ theme }) => theme.colors.primary};
   }
 \`;
 
@@ -142,7 +165,7 @@ const StyledContent = styled.div<{
     \`}
 \`;
 
-function ActionBar({ children, content }: ActionBarProps) {
+function ActionBar({ children, content, rssHref }: ActionBarProps) {
   const [isView, setIsView] = useState(true);
   const [copied, setCopied] = useState(false);
   const hasSectionBar = useContext(SectionBarContext);
@@ -160,19 +183,27 @@ function ActionBar({ children, content }: ActionBarProps) {
   return (
     <>
       <StyledActionBar>
-        <StyledCopyButton onClick={handleCopyContent} $copied={copied}>
-          {copied ? (
-            <>
-              <Icon name="check" size={16} />
-              Copied!
-            </>
-          ) : (
-            <>
-              <Icon name="copy" size={16} />
-              Copy content
-            </>
+        <StyledActionBarGroup>
+          <StyledCopyButton onClick={handleCopyContent} $copied={copied}>
+            {copied ? (
+              <>
+                <Icon name="check" size={16} />
+                Copied!
+              </>
+            ) : (
+              <>
+                <Icon name="copy" size={16} />
+                Copy content
+              </>
+            )}
+          </StyledCopyButton>
+          {rssHref && (
+            <StyledRssLink as="a" href={rssHref} aria-label="RSS feed">
+              <Icon name="rss" size={16} />
+              RSS
+            </StyledRssLink>
           )}
-        </StyledCopyButton>
+        </StyledActionBarGroup>
         <StyledActionBarContent>
           <StyledToggle
             onClick={() => setIsView(!isView)}

--- a/src/templates/components/layout/Update.ts
+++ b/src/templates/components/layout/Update.ts
@@ -64,6 +64,9 @@ interface UpdateProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   label: string;
   description?: string;
+  // Alternative pure-Markdown text for this entry in the page's RSS feed.
+  // Consumed at generation time; never rendered on the page.
+  rss?: string;
 }
 
 function Update({ children, label = "Label", description, id }: UpdateProps) {

--- a/src/templates/lib/rss.ts
+++ b/src/templates/lib/rss.ts
@@ -1,0 +1,78 @@
+export const rssLibTemplate = `import { config } from "@/utils/config";
+
+export interface RssItem {
+  title: string;
+  anchor: string;
+  description: string;
+}
+
+export interface RssFeedData {
+  // Page path relative to the site root, e.g. "update" or "guides/setup".
+  pagePath: string;
+  // Channel title; null falls back to the site name from config.json.
+  title: string | null;
+  // Channel description; null falls back to the config.json description.
+  description: string | null;
+  items: RssItem[];
+}
+
+// Same base-URL resolution as sitemap.ts/robots.ts: env override first, then
+// config.json. Without either, feed links degrade to root-relative paths.
+function resolveBaseUrl(): string | null {
+  const raw = process.env.NEXT_PUBLIC_SITE_URL ?? config.url;
+  if (!raw) return null;
+  return raw.replace(/\\/$/, "");
+}
+
+// Ampersand first, or it would re-escape the other entities.
+function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+// Builds the RSS 2.0 document for a page's subscribable changelog. Entry
+// descriptions arrive as pure Markdown (components, code, and HTML were
+// removed at generation time) and are entity-escaped here, so no CDATA
+// sections are needed. Entries carry no pubDate: the guid is the entry's
+// permalink, so feed readers surface new entries when new guids appear.
+export function buildRssFeed(feed: RssFeedData): string {
+  const base = resolveBaseUrl();
+  const pageUrl = base ? \`\${base}/\${feed.pagePath}\` : \`/\${feed.pagePath}\`;
+  const feedUrl = \`\${pageUrl}/rss.xml\`;
+  const siteName = config.name || "Documentation";
+  const title = feed.title ?? siteName;
+  const description = feed.description ?? config.description ?? title;
+
+  const items = feed.items.map((item) => {
+    const link = \`\${pageUrl}#\${item.anchor}\`;
+    return [
+      "    <item>",
+      \`      <title>\${escapeXml(item.title)}</title>\`,
+      \`      <link>\${escapeXml(link)}</link>\`,
+      \`      <guid isPermaLink="true">\${escapeXml(link)}</guid>\`,
+      \`      <description>\${escapeXml(item.description)}</description>\`,
+      "    </item>",
+    ].join("\\n");
+  });
+
+  return [
+    \`<?xml version="1.0" encoding="UTF-8"?>\`,
+    \`<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">\`,
+    "  <channel>",
+    \`    <title>\${escapeXml(title)}</title>\`,
+    \`    <link>\${escapeXml(pageUrl)}</link>\`,
+    \`    <description>\${escapeXml(description)}</description>\`,
+    \`    <atom:link href="\${escapeXml(feedUrl)}" rel="self" type="application/rss+xml" />\`,
+    \`    <lastBuildDate>\${new Date().toUTCString()}</lastBuildDate>\`,
+    \`    <copyright>\${escapeXml(siteName)}</copyright>\`,
+    ...items,
+    "  </channel>",
+    "</rss>",
+    "",
+  ].join("\\n");
+}
+`;

--- a/src/templates/mdx/components.mdx.ts
+++ b/src/templates/mdx/components.mdx.ts
@@ -58,7 +58,7 @@ Doccupine includes a rich set of built-in components you can use directly in you
     Interactive API reference where readers send real requests and see live responses.
   </Card>
   <Card title="Update" icon="bell" href="/update">
-    Changelog and update announcement blocks.
+    Changelog blocks with a subscribable RSS feed.
   </Card>
   <Card title="Color Swatches" icon="palette" href="/color-swatches">
     Visual color palette swatches to document your theme colors.

--- a/src/templates/mdx/update.mdx.ts
+++ b/src/templates/mdx/update.mdx.ts
@@ -5,6 +5,7 @@ date: "2026-02-19"
 category: "Components"
 categoryOrder: 1
 order: 16
+rss: true
 ---
 # Update
 
@@ -48,15 +49,54 @@ You can combine multiple \`Update\` components to build complete changelogs.
 </Update>
 \`\`\`
 
+## Subscribable changelogs
+
+Every page that contains at least one \`Update\` component automatically publishes an RSS feed at its page URL with \`/rss.xml\` appended. For example, this page's feed lives at \`/update/rss.xml\`.
+
+Each \`Update\` becomes a feed entry: the \`label\` is the entry title, and the entry link deep-links to the update's anchor on the page. New entries reach subscribers as soon as the site is rebuilt with new \`Update\` components.
+
+Feed entries contain pure Markdown only. They exclude components, code, and HTML elements. Use the \`rss\` property to provide alternative text for feed readers when an update consists mostly of excluded content:
+
+\`\`\`html
+<Update label="v0.0.2" rss="Added dark mode and fixed sidebar links.">
+  <Frame>![Dark mode](https://docs.doccupine.com/demo.png)</Frame>
+</Update>
+\`\`\`
+
+The feed's channel title and description come from the page frontmatter, falling back to the site name and description from \`config.json\`. RSS feeds are only available on public documentation - password-protected sites do not expose them.
+
+RSS feeds can integrate with Slack, email, or other subscription tools to notify readers of changes. Some options include:
+
+- [Slack](https://slack.com/help/articles/218688467-Add-RSS-feeds-to-Slack)
+- [Email](https://zapier.com/apps/email/integrations/rss/1441/send-new-rss-feed-entries-via-email) via Zapier
+- Discord bots like [Readybot](https://readybot.io)
+
+## RSS button
+
+To make the feed discoverable, add \`rss: true\` to the page frontmatter. This displays an RSS button at the top of the page that links to the feed - this page shows one. The button only appears when the page actually contains \`Update\` components.
+
+\`\`\`yaml
+---
+rss: true
+---
+\`\`\`
+
 ## Properties
 
 <Field value="label" type="string" required>
   The label of the update. It also appears in the page's "On this page"
-  navigation and acts as a deep-link anchor to this entry.
+  navigation, acts as a deep-link anchor to this entry, and becomes the entry
+  title in the page's RSS feed.
 </Field>
 
 <Field value="description" type="string">
   An optional description for the update. When omitted, no description is shown.
+</Field>
+
+<Field value="rss" type="string">
+  Alternative pure-Markdown text for this entry in the page's RSS feed. When
+  omitted, the feed uses the entry content with components, code, and HTML
+  removed. Never rendered on the page.
 </Field>
 
 <Field value="children" type="node" required>


### PR DESCRIPTION
## Summary

Any docs page containing at least one `<Update>` component now publishes an RSS 2.0 feed at `{page-url}/rss.xml`, so a changelog page becomes something readers can subscribe to from Slack, email, or any feed reader.

- **Feed generation.** A new parser (`src/lib/rss.ts`) extracts `<Update>` blocks from the page MDX at generation time and emits a force-static `app/(site)/{slug}/rss.xml/route.ts` per page (new `src/templates/app/rssRoute.ts`), rendered by a shared generated helper at `lib/rss.ts` (new `src/templates/lib/rss.ts`, registered in `src/lib/structures.ts`).
- **Entries.** The Update's `label` becomes the entry title, link and guid deep-link to the entry's anchor on the page, and the body is the Update's content reduced to pure Markdown: components, code, and HTML are removed and images collapse to their alt text.
- **New `rss` prop** on `<Update>` supplies alternative feed-only text for entries made mostly of excluded content. It is consumed at generation time and never rendered on the page.
- **Discovery.** Pages with a feed emit an `alternates.types` autodiscovery link in their metadata (`src/lib/metadata.ts`), and `rss: true` frontmatter adds an RSS button to the action bar via a new optional `rssHref` prop threaded from `Docs` into `ActionBar`.
- **Lifecycle.** The feed route lives inside the page's own directory, so a deleted page takes its feed with it, and the route is pruned when a regenerated page no longer has Update blocks.
- **Docs.** The Update page gains "Subscribable changelogs" and "RSS button" sections plus an `rss` property field, and opts into `rss: true` itself so the generated demo site ships a live example. The Components index card and the README feature list mention the feature.

## Worth a reviewer's eye

**Anchor parity is the load-bearing constraint.** A feed link only resolves if its anchor byte-matches the id the generated app assigns. The generated app runs one shared slugger over the fenced-code-stripped document, collecting markdown headings *and* `<Update label>` open tags in document order, so headings consume slugger slots too: an `## Setup` before `<Update label="Setup">` pushes that entry's anchor to `setup-1`. `src/lib/rss.ts` replays that entire walk rather than slugging labels in isolation, and `src/lib/rss.test.ts` pins the template sources so the port cannot drift from them unnoticed.

**Format stability.** Both emitters pre-wrap their output in the shape Prettier produces rather than shelling out to a formatter, matching the existing OpenAPI operation embed. That is why `metadata.ts` and `rssRoute.ts` carry explicit 80-column width checks.

**No per-item `pubDate`.** The CLI holds no state across runs, so there is no honest publication date to emit; new permalink guids are what surface new entries to readers. Password-gated sites deliberately do not expose feeds.

## Related issues

None.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Template or generated-output change
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] `pnpm build && pnpm test` passes locally
- [x] I tested the change against a real generated app (the integration test drives `dist/index.js build`, and the feature was also exercised through `next build` on a generated app)
- [x] New templates follow the `camelCaseTemplate` naming convention and are wired into `createNextJSStructure()` (`rssLibTemplate` is registered in `appStructure`; `rssRouteTemplate` is emitted per page from `generatePageFromMDX`, since feed routes are per-page rather than fixed structure entries)
- [x] Generated output is prettier-stable (no formatting churn introduced)
- [x] I did not commit secrets or `.env` files
- [x] The PR is focused on a single feature or fix

## Testing

- `pnpm build` (tsc) exit 0 and `pnpm test` 75/75 passing across 3 test files, re-run on this branch.
- The integration test in `src/index.test.ts` runs the real CLI (`dist/index.js build`) against a temp project, asserts the generated `out/app/(site)/update/rss.xml/route.ts` exists, and then runs `prettier --check .` over the whole generated app honoring its own `.prettierrc`/`.prettierignore`. So the new feed route and the RSS-button page shape are both covered by the generated-output format check, not just by unit tests.
- `src/lib/rss.test.ts` adds unit coverage for the slugger port, the heading/Update interleaving that shifts anchors, the Markdown reduction, and drift guards pinning the template sources.
- Verified end to end against a generated app before this PR: `next build` succeeds, `/update/rss.xml` prerenders as static XML, the rendered page's anchor id matches the feed link anchor exactly, and both the RSS button and the autodiscovery `<link>` render.
- `prettier --check` is clean on every file this PR touches. `README.md` also reports as unformatted, but that is pre-existing drift in the configuration-files table (the version at `d9b6222` fails the same check) and was deliberately left alone rather than swept into this PR.

## Note on `update.mdx.ts` frontmatter `order`

This PR keeps `order: 16`, which matches both the Components sidebar sequence and the Components index grid at this branch's base. A `16 -> 20` renumber of this page exists in separate in-flight work that adds several new component pages and renumbers the whole Components category, index grid included; it belongs to that change and will land with it. The only overlap between the two is the adjacent `rss: true` frontmatter line, which merges cleanly.
