### PR TITLE
feat(templates): make generated docs agent-ready

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ import {
   type PageWithBody,
 } from "./templates/llms/llmsFull.js";
 import { llmsPageTemplate } from "./templates/llms/llmsPage.js";
+import { skillMdTemplate, slugifySiteName } from "./templates/llms/skillMd.js";
 import type {
   DoccupineConfig,
   MDXFile,
@@ -2223,6 +2224,38 @@ export default function Page() {
       fullContent,
       "utf8",
     );
+
+    const skillContent = skillMdTemplate({
+      siteName: name,
+      siteDescription: description,
+      baseUrl,
+      pages: resolvedPages,
+      sectionsConfig: this.sectionsConfig,
+    });
+    await fs.writeFile(path.join(publicDir, "skill.md"), skillContent, "utf8");
+
+    // MCP discovery manifest. Needs an absolute URL, so it only exists when
+    // config.json declares the site url; it is pruned if the url is removed.
+    const mcpJsonPath = path.join(publicDir, ".well-known", "mcp.json");
+    if (baseUrl) {
+      const mcpJson =
+        JSON.stringify(
+          {
+            mcpServers: {
+              [`${slugifySiteName(name)}-docs`]: {
+                url: `${baseUrl}/api/mcp`,
+                transport: "streamable-http",
+              },
+            },
+          },
+          null,
+          2,
+        ) + "\n";
+      await fs.ensureDir(path.dirname(mcpJsonPath));
+      await fs.writeFile(mcpJsonPath, mcpJson, "utf8");
+    } else if (await fs.pathExists(mcpJsonPath)) {
+      await fs.remove(mcpJsonPath);
+    }
 
     const nextRelativePaths = new Set<string>();
     await Promise.all(

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ import {
   type PageWithBody,
 } from "./templates/llms/llmsFull.js";
 import { llmsPageTemplate } from "./templates/llms/llmsPage.js";
-import { skillMdTemplate, slugifySiteName } from "./templates/llms/skillMd.js";
+import { siteDocsSlug, skillMdTemplate } from "./templates/llms/skillMd.js";
 import type {
   DoccupineConfig,
   MDXFile,
@@ -2242,7 +2242,7 @@ export default function Page() {
         JSON.stringify(
           {
             mcpServers: {
-              [`${slugifySiteName(name)}-docs`]: {
+              [siteDocsSlug(name)]: {
                 url: `${baseUrl}/api/mcp`,
                 transport: "streamable-http",
               },

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -242,7 +242,7 @@ ${
     : `import { Footer } from "@/components/layout/Footer";
 `
 }import { Header } from "@/components/layout/Header";
-import { DocsWrapper } from "@/components/layout/DocsComponents";
+import { DocsWrapper, LlmsDirective } from "@/components/layout/DocsComponents";
 ${
   hasSections
     ? ""
@@ -288,6 +288,7 @@ ${
   return (
     ${chtOpen}
       <SearchProvider pages={pages} sections={doccupineSections}>
+        <LlmsDirective />
         <Header>
           <SectionBar sections={doccupineSections} />
         </Header>
@@ -330,6 +331,7 @@ ${
   return (
     ${chtOpen}
       <SearchProvider pages={pages}>
+        <LlmsDirective />
         <Header />
         {process.env.LLM_PROVIDER && <Chat />}
         <SectionBarProvider hasSectionBar={false}>

--- a/src/templates/components/Chat.ts
+++ b/src/templates/components/Chat.ts
@@ -815,7 +815,7 @@ function Chat() {
 
   return (
     <>
-      <StyledChat $isVisible={isOpen}>
+      <StyledChat $isVisible={isOpen} data-markdown-ignore>
         <StyledChatTitle>
           <StyledChatTitleIconWrapper>
             <Sparkles />
@@ -895,7 +895,7 @@ function Chat() {
         <div ref={endRef} />
       </StyledChat>
 
-      <StyledChatForm onSubmit={ask} $isVisible={isOpen}>
+      <StyledChatForm onSubmit={ask} $isVisible={isOpen} data-markdown-ignore>
         <RainbowInput
           id="chat-bottom-input"
           inputRef={chatInputRef}

--- a/src/templates/components/DocsSideBar.ts
+++ b/src/templates/components/DocsSideBar.ts
@@ -143,7 +143,7 @@ export function DocsSideBar({ headings }: { headings: Heading[] }) {
   };
 
   return (
-    <StyledIndexSidebar data-sidebar>
+    <StyledIndexSidebar data-sidebar data-markdown-ignore>
       {headings?.length > 0 && (
         <li aria-hidden="true">
           <StyledIndexSidebarLabel>On this page</StyledIndexSidebarLabel>

--- a/src/templates/components/layout/ActionBar.ts
+++ b/src/templates/components/layout/ActionBar.ts
@@ -1,5 +1,6 @@
 export const actionBarTemplate = `"use client";
 import { useContext, useState } from "react";
+import { usePathname } from "next/navigation";
 import styled, { css } from "styled-components";
 import { Icon } from "@/components/layout/Icon";
 import { mq, Theme } from "@/app/theme";
@@ -39,6 +40,8 @@ const StyledActionBar = styled.div<{
 \`;
 
 const StyledActionBarContent = styled.div\`
+  display: flex;
+  gap: 12px;
   margin: auto 0;
 \`;
 
@@ -79,26 +82,57 @@ const StyledRssLink = styled(StyledSmallButton)<{ theme: Theme }>\`
   }
 \`;
 
-// Mirrors the geometry and interaction of Cherry's ThemeToggle so the two
-// pills look identical side by side: interactiveStyles supplies the border
-// highlight + focus/active rings (no scale effect), and the space-between
-// layout with 6px padding puts each 16px icon's center exactly where the
-// 24px knob's center sits in its resting (left: 2px) and active
-// (translateX(26px)) positions.
-const StyledToggle = styled.button<{ theme: Theme; $isActive?: boolean }>\`
-  \${resetButton}
-  \${interactiveStyles}
-  width: 56px;
+// Mirrors the geometry and interaction of Cherry's ThemeToggle so every pill
+// on this side of the bar looks identical: interactiveStyles supplies the
+// border highlight + focus/active rings (no scale effect), and the 30px
+// height with a fully rounded radius matches the toggle's knob track.
+const actionPillStyles = (theme: Theme) => css\`
   height: 30px;
   border-radius: 30px;
   display: flex;
   align-items: center;
+  margin: auto 0;
+  background: \${theme.colors.light};
+  border-color: \${theme.colors.grayLight};
+
+  & svg {
+    width: 16px;
+    height: 16px;
+    object-fit: contain;
+    transition: all 0.3s ease;
+    position: relative;
+    z-index: 2;
+  }
+
+  & svg[stroke] {
+    stroke: \${theme.colors.primary};
+  }
+
+  &:hover svg[stroke] {
+    stroke: \${theme.colors.accent};
+  }
+\`;
+
+const StyledMarkdownLink = styled.a<{ theme: Theme }>\`
+  \${resetButton}
+  \${interactiveStyles}
+  \${({ theme }) => actionPillStyles(theme)}
+  width: 30px;
+  justify-content: center;
+  text-decoration: none;
+\`;
+
+// The space-between layout with 6px padding puts each 16px icon's center
+// exactly where the 24px knob's center sits in its resting (left: 2px) and
+// active (translateX(26px)) positions.
+const StyledToggle = styled.button<{ theme: Theme; $isActive?: boolean }>\`
+  \${resetButton}
+  \${interactiveStyles}
+  \${({ theme }) => actionPillStyles(theme)}
+  width: 56px;
   justify-content: space-between;
   padding: 0 6px;
   position: relative;
-  margin: auto 0;
-  background: \${({ theme }) => theme.colors.light};
-  border-color: \${({ theme }) => theme.colors.grayLight};
 
   &::after {
     content: "";
@@ -117,23 +151,6 @@ const StyledToggle = styled.button<{ theme: Theme; $isActive?: boolean }>\`
       css\`
         transform: translateX(26px);
       \`}
-  }
-
-  & svg {
-    width: 16px;
-    height: 16px;
-    object-fit: contain;
-    transition: all 0.3s ease;
-    position: relative;
-    z-index: 2;
-  }
-
-  & svg[stroke] {
-    stroke: \${({ theme }) => theme.colors.primary};
-  }
-
-  &:hover svg[stroke] {
-    stroke: \${({ theme }) => theme.colors.accent};
   }
 \`;
 
@@ -166,10 +183,18 @@ const StyledContent = styled.div<{
     \`}
 \`;
 
+// Every page ships a static markdown mirror under public/: "/" serves
+// "/index.md" and "/{slug}" serves "/{slug}.md".
+function toMarkdownHref(pathname: string) {
+  const base = pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+  return \`\${base === "" ? "/index" : base}.md\`;
+}
+
 function ActionBar({ children, content, rssHref }: ActionBarProps) {
   const [isView, setIsView] = useState(true);
   const [copied, setCopied] = useState(false);
   const hasSectionBar = useContext(SectionBarContext);
+  const pathname = usePathname();
 
   const handleCopyContent = async () => {
     try {
@@ -183,7 +208,7 @@ function ActionBar({ children, content, rssHref }: ActionBarProps) {
 
   return (
     <>
-      <StyledActionBar>
+      <StyledActionBar data-markdown-ignore>
         <StyledActionBarGroup>
           <StyledCopyButton onClick={handleCopyContent} $copied={copied}>
             {copied ? (
@@ -206,6 +231,13 @@ function ActionBar({ children, content, rssHref }: ActionBarProps) {
           )}
         </StyledActionBarGroup>
         <StyledActionBarContent>
+          <StyledMarkdownLink
+            href={toMarkdownHref(pathname)}
+            aria-label="View as Markdown"
+            title="View as Markdown"
+          >
+            <Icon name="FileText" />
+          </StyledMarkdownLink>
           <StyledToggle
             onClick={() => setIsView(!isView)}
             aria-label="Toggle View"

--- a/src/templates/components/layout/DocsComponents.ts
+++ b/src/templates/components/layout/DocsComponents.ts
@@ -42,7 +42,7 @@ interface DocsProps {
   children: React.ReactNode;
 }
 
-const StyledDocsWrapper = styled.main<{ theme: Theme }>\`
+const StyledDocsWrapper = styled.div<{ theme: Theme }>\`
   position: relative;
 \`;
 
@@ -50,7 +50,13 @@ const StyledDocsSidebar = styled.div<{ theme: Theme }>\`
   clear: both;
 \`;
 
-const StyledDocsContainer = styled.div<{ theme: Theme; $isChatOpen?: boolean }>\`
+// The <main> landmark wraps only the article content: the sidebar, footer,
+// and nav render outside it so content extractors and assistive tech start at
+// the article.
+const StyledDocsContainer = styled.main<{
+  theme: Theme;
+  $isChatOpen?: boolean;
+}>\`
   position: relative;
   padding: 0 20px 100px 20px;
   width: 100%;
@@ -536,6 +542,30 @@ export const StyledMissingComponent = styled.div\`
   align-items: center;
 \`;
 
+// Visually hidden but present for crawlers and agents: points at llms.txt and
+// the .md mirrors. Rendered as the first element of the site layout.
+const StyledLlmsDirective = styled.div\`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+\`;
+
+function LlmsDirective() {
+  return (
+    <StyledLlmsDirective data-markdown-ignore>
+      <a href="/llms.txt">Documentation index for AI agents (llms.txt)</a>.
+      Markdown versions of every page are available by appending .md to the page
+      URL. The full corpus is at <a href="/llms-full.txt">/llms-full.txt</a>.
+    </StyledLlmsDirective>
+  );
+}
+
 interface DocsWrapperProps {
   children: React.ReactNode;
 }
@@ -560,6 +590,7 @@ export {
   DocsWrapper,
   DocsSidebar,
   DocsContainer,
+  LlmsDirective,
   SectionBarContext,
   SectionBarProvider,
 };

--- a/src/templates/llms/llmsIndex.ts
+++ b/src/templates/llms/llmsIndex.ts
@@ -8,24 +8,25 @@ export interface LlmsIndexArgs {
   sectionsConfig: SectionConfig[] | null;
 }
 
-interface CategoryGroup {
+export interface CategoryGroup {
   category: string;
   minCategoryOrder: number;
   pages: PageMeta[];
 }
 
-interface SectionGroup {
+export interface SectionGroup {
   sectionSlug: string;
   sectionLabel: string;
   sectionOrder: number;
   categories: CategoryGroup[];
 }
 
-function pageUrl(slug: string, baseUrl: string | null): string {
-  if (baseUrl) {
-    return slug === "" ? `${baseUrl}/` : `${baseUrl}/${slug}`;
-  }
-  return slug === "" ? "/" : `/${slug}`;
+// Index links point at the static markdown mirrors (public/{slug}.md) so
+// agents get clean markdown directly; the HTML page is the same URL without
+// the .md suffix.
+export function pageUrl(slug: string, baseUrl: string | null): string {
+  const prefix = baseUrl ?? "";
+  return slug === "" ? `${prefix}/index.md` : `${prefix}/${slug}.md`;
 }
 
 function comparePages(a: PageMeta, b: PageMeta): number {
@@ -33,7 +34,7 @@ function comparePages(a: PageMeta, b: PageMeta): number {
   return a.title.localeCompare(b.title);
 }
 
-function buildSectionGroups(
+export function buildSectionGroups(
   pages: PageMeta[],
   sectionsConfig: SectionConfig[] | null,
 ): SectionGroup[] {
@@ -111,12 +112,25 @@ export function llmsIndexTemplate(args: LlmsIndexArgs): string {
   const { siteName, siteDescription, baseUrl, pages, sectionsConfig } = args;
   const lines: string[] = [];
 
+  const prefix = baseUrl ?? "";
+
   lines.push(`# ${siteName}`);
   lines.push("");
-  if (siteDescription && siteDescription.trim() !== "") {
-    lines.push(`> ${siteDescription.trim()}`);
-    lines.push("");
-  }
+  const summary =
+    siteDescription && siteDescription.trim() !== ""
+      ? siteDescription.trim()
+      : `Documentation for ${siteName}.`;
+  lines.push(`> ${summary}`);
+  lines.push("");
+  lines.push(
+    "Every page link below points to a markdown mirror; drop the .md suffix for the HTML version.",
+  );
+  lines.push(`Full corpus in one file: ${prefix}/llms-full.txt`);
+  lines.push(`Agent skill: ${prefix}/skill.md`);
+  lines.push(
+    `MCP server (streamable HTTP; tools: search_docs, get_doc, list_docs): ${prefix}/api/mcp`,
+  );
+  lines.push("");
 
   if (pages.length === 0) {
     return lines.join("\n") + "\n";

--- a/src/templates/llms/llmsPage.ts
+++ b/src/templates/llms/llmsPage.ts
@@ -20,6 +20,10 @@ export function llmsPageTemplate(
   }
   lines.push(`Source: ${pageUrl(page.slug, baseUrl)}`);
   lines.push("");
+  lines.push(
+    `> For the complete documentation index, see [llms.txt](${baseUrl ?? ""}/llms.txt).`,
+  );
+  lines.push("");
   lines.push(page.body.trim());
   lines.push("");
   return lines.join("\n");

--- a/src/templates/llms/skillMd.ts
+++ b/src/templates/llms/skillMd.ts
@@ -11,12 +11,20 @@ export interface SkillMdArgs {
 
 const KEY_PAGE_LIMIT = 8;
 
-export function slugifySiteName(siteName: string): string {
+function slugifySiteName(siteName: string): string {
   const slug = siteName
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
   return slug === "" ? "docs" : slug;
+}
+
+// Identifier for the skill name and the MCP discovery manifest. Skips the
+// -docs suffix when the site name already ends in "docs" ("Acme Docs" ->
+// acme-docs, not acme-docs-docs).
+export function siteDocsSlug(siteName: string): string {
+  const slug = slugifySiteName(siteName);
+  return slug === "docs" || slug.endsWith("-docs") ? slug : `${slug}-docs`;
 }
 
 // Agent skill definition served at /skill.md: tells agents how to read the
@@ -35,7 +43,7 @@ export function skillMdTemplate(args: SkillMdArgs): string {
 
   const lines: string[] = [];
   lines.push("---");
-  lines.push(`name: ${slugifySiteName(siteName)}-docs`);
+  lines.push(`name: ${siteDocsSlug(siteName)}`);
   lines.push(`description: ${JSON.stringify(description)}`);
   lines.push("---");
   lines.push("");

--- a/src/templates/llms/skillMd.ts
+++ b/src/templates/llms/skillMd.ts
@@ -1,0 +1,71 @@
+import type { PageMeta, SectionConfig } from "../../lib/types.js";
+import { buildSectionGroups, pageUrl } from "./llmsIndex.js";
+
+export interface SkillMdArgs {
+  siteName: string;
+  siteDescription?: string;
+  baseUrl: string | null;
+  pages: PageMeta[];
+  sectionsConfig: SectionConfig[] | null;
+}
+
+const KEY_PAGE_LIMIT = 8;
+
+export function slugifySiteName(siteName: string): string {
+  const slug = siteName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug === "" ? "docs" : slug;
+}
+
+// Agent skill definition served at /skill.md: tells agents how to read the
+// docs (llms.txt index, .md mirrors, MCP server) and lists the first pages in
+// navigation order as entry points. A user-authored public/skill.md in the
+// watch dir overrides this file, since public assets are copied afterwards.
+export function skillMdTemplate(args: SkillMdArgs): string {
+  const { siteName, siteDescription, baseUrl, pages, sectionsConfig } = args;
+  const prefix = baseUrl ?? "";
+  const description = `Navigate and use the ${siteName} documentation. Use when answering questions about ${siteName} or working with its docs.`;
+
+  const keyPages = buildSectionGroups(pages, sectionsConfig)
+    .flatMap((group) => group.categories)
+    .flatMap((cat) => cat.pages)
+    .slice(0, KEY_PAGE_LIMIT);
+
+  const lines: string[] = [];
+  lines.push("---");
+  lines.push(`name: ${slugifySiteName(siteName)}-docs`);
+  lines.push(`description: ${JSON.stringify(description)}`);
+  lines.push("---");
+  lines.push("");
+  lines.push(`# ${siteName} documentation`);
+  lines.push("");
+  if (siteDescription && siteDescription.trim() !== "") {
+    lines.push(siteDescription.trim());
+    lines.push("");
+  }
+  lines.push("## Reading these docs");
+  lines.push("");
+  lines.push(
+    `- Documentation index: ${prefix}/llms.txt (full corpus: ${prefix}/llms-full.txt)`,
+  );
+  lines.push("- Every page has a markdown mirror: append .md to the page URL");
+  lines.push(
+    `- MCP server with search_docs, get_doc, and list_docs tools: ${prefix}/api/mcp (streamable HTTP)`,
+  );
+  lines.push("");
+  if (keyPages.length > 0) {
+    lines.push("## Key pages");
+    lines.push("");
+    for (const page of keyPages) {
+      const desc =
+        page.description && page.description.trim() !== ""
+          ? ` - ${page.description.trim()}`
+          : "";
+      lines.push(`- [${page.title}](${pageUrl(page.slug, baseUrl)})${desc}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}

--- a/src/templates/next.config.ts
+++ b/src/templates/next.config.ts
@@ -19,6 +19,16 @@ const nextConfig: NextConfig = {
     "/api/rag": ["./services/mcp/docs-index.json"],
     "/api/mcp": ["./services/mcp/docs-index.json"],
   },
+  // Discovery alias: agents probe /mcp for an MCP server. Auth for the alias
+  // is handled in the middleware, which runs before this rewrite.
+  async rewrites() {
+    return [
+      {
+        source: "/mcp",
+        destination: "/api/mcp",
+      },
+    ];
+  },
 };
 
 export default nextConfig;
@@ -44,8 +54,15 @@ const nextConfig: NextConfig = {
     "/api/rag": ["./services/mcp/docs-index.json"],
     "/api/mcp": ["./services/mcp/docs-index.json"],
   },
+  // The /mcp entry is a discovery alias: agents probe /mcp for an MCP server.
+  // Auth for the alias is handled in the middleware, which runs before this
+  // rewrite.
   async rewrites() {
     return [
+      {
+        source: "/mcp",
+        destination: "/api/mcp",
+      },
       {
         source: "/ingest/static/:path*",
         destination: "${assetsHost}/static/:path*",

--- a/src/templates/proxy.ts
+++ b/src/templates/proxy.ts
@@ -269,8 +269,10 @@ ${fnSignature} {
 ${trackingInit}  const pathname = req.nextUrl.pathname;
   const sitePassword = process.env.SITE_PASSWORD;
 
-  // API key auth for /api/mcp when DOCS_API_KEY is configured
-  if (pathname.startsWith("/api/mcp")) {
+  // API key auth for the MCP endpoint when DOCS_API_KEY is configured. Also
+  // matches /mcp, the discovery alias that next.config rewrites to /api/mcp
+  // after the middleware has run.
+  if (pathname.startsWith("/api/mcp") || pathname === "/mcp") {
     const apiKey = process.env.DOCS_API_KEY;
     if (apiKey) {
       const authHeader = req.headers.get("authorization");
@@ -320,6 +322,32 @@ ${trackingInit}  const pathname = req.nextUrl.pathname;
         tracking,
       );
     }
+  }
+
+  // Content negotiation: agents that request markdown (Accept: text/markdown)
+  // are served the page's static .md mirror from public/. Runs after the
+  // SITE_PASSWORD gate so protected sites never expose markdown around the
+  // login screen. Only extensionless GET paths are rewritten, so assets, API
+  // routes, and the MCP alias stay untouched. The rewrite target is part of
+  // the CDN cache key, so HTML responses stay cacheable without a Vary header.
+  const accept = req.headers.get("accept") ?? "";
+  if (
+    req.method === "GET" &&
+    accept.includes("text/markdown") &&
+    !pathname.startsWith("/api") &&
+    !pathname.startsWith("/_next") &&
+    pathname !== "/gate" &&
+    pathname !== "/mcp" &&
+    !/\\.[a-z0-9]+$/i.test(pathname)
+  ) {
+    const url = req.nextUrl.clone();
+    url.pathname =
+      pathname === "/" ? "/index.md" : pathname.replace(/\\/$/, "") + ".md";
+    const mdRes = NextResponse.rewrite(url);
+    if (sitePassword) {
+      mdRes.headers.set("X-Robots-Tag", "noindex, nofollow");
+    }
+    return applyTracking(mdRes, tracking);
   }
 
   const res = NextResponse.next();


### PR DESCRIPTION
## Summary

Makes generated documentation sites agent-ready. An agent arriving at a
generated site can now discover what is on offer and fetch it in the shape it
wants: `llms.txt` indexes the corpus and advertises everything else, every page
has a static markdown mirror it can fetch directly, a request that asks for
markdown is served markdown, the MCP server is announced where agents look for
it, and an agent skill spells out how to use all of it. The site chrome is
marked so HTML-to-markdown extractors keep the article and drop the furniture.

These changes take effect on generated sites after the next CLI release and a
site rebuild.

## Changes

**llms.txt and the markdown mirrors**

- `llms.txt` always emits an H1 and a blockquote summary, falling back to
  "Documentation for {name}." when `config.json` carries no description.
- Page links point at the `.md` mirrors (the homepage at `/index.md`), and the
  header advertises `llms-full.txt`, `skill.md`, and the MCP server at
  `/api/mcp`.
- `buildSectionGroups`, `pageUrl`, and the group interfaces are exported so the
  skill template can reuse the navigation ordering.
- Each `{slug}.md` mirror carries a blockquote near the top pointing back at
  `llms.txt`.

**Agent skill**

- New `public/skill.md` with frontmatter (name, description), a "Reading these
  docs" section covering `llms.txt`, the `.md` mirrors and the MCP tools, and
  the first eight pages in navigation order as entry points.
- A user-authored `public/skill.md` in the watch directory overrides it, since
  public assets are copied afterwards.

**MCP discoverability**

- `public/.well-known/mcp.json` is generated when `config.json` declares a site
  url, and pruned when that url is removed.
- `/mcp` rewrites to `/api/mcp` in both branches of the generated
  `next.config.ts`.
- The middleware's `DOCS_API_KEY` check now also matches `/mcp`, so the
  discovery alias cannot be used to bypass auth on a key-protected site.

**Content negotiation**

- `GET` requests sending `Accept: text/markdown` on extensionless paths are
  rewritten to the page's static `.md` mirror.
- This runs after the `SITE_PASSWORD` gate, so a protected site never serves
  markdown around its login screen, and the `X-Robots-Tag` backstop stays on
  gated responses.
- No `Vary` header is set: the rewrite target is part of the CDN cache key, so
  pages stay edge-cacheable.

**Markup**

- A visually hidden `LlmsDirective` links `/llms.txt` and `/llms-full.txt` and
  notes the `.md` mirrors. It renders as the first element of the layout in both
  the sectioned and unsectioned branches.
- The `<main>` landmark now wraps only the article: `StyledDocsWrapper` became a
  `div` and `StyledDocsContainer` became the `main`, so the sidebar, nav, and
  footer no longer sit inside it.
- The ActionBar gained a "View as Markdown" link to the current page's `.md`
  mirror, sharing the view toggle's 30px pill geometry through an extracted
  style helper.
- The ActionBar chrome, the "On this page" list, and the chat panel and its
  input form are marked `data-markdown-ignore`.

## Related issues

n/a

## Verification

- `pnpm build` clean, `pnpm test` 78/78 across 3 files. The integration suite
  runs the real `dist/index.js build` in a temp project and then
  `prettier --check` over the whole generated app, so generated output is
  confirmed prettier-stable.
- The generated app typechecks with `tsc --noEmit`.
- Generated a real site in a scratch directory with `node dist/index.js build`
  and inspected the output:
  - `llms.txt` with the H1, blockquote summary, and the llms-full/skill/MCP
    header, in both the relative-URL and absolute-URL (`config.json` url) cases.
  - `index.md` and `{slug}.md` mirrors carrying the llms.txt blockquote.
  - `skill.md` with frontmatter and the key-pages list.
  - `.well-known/mcp.json` emitted when the site url is set, and confirmed gone
    after removing the url and rebuilding.
  - Middleware rewrites and the layout markup reviewed in the emitted templates.
- `npx prettier --check` clean on all changed source files.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Template or generated-output change
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] `pnpm build && pnpm test` passes locally
- [x] I tested the change against a real generated app (`node dist/index.js build` in a scratch directory) when it affects generation
- [x] New templates follow the `camelCaseTemplate` naming convention and are wired into `createNextJSStructure()` - `skillMdTemplate` follows the convention; like the other `llms/` templates it is emitted from `updateLlmsFiles()` into `public/` rather than through `createNextJSStructure()`
- [x] Generated output is prettier-stable (no formatting churn introduced)
- [x] I did not commit secrets or `.env` files
- [x] The PR is focused on a single feature or fix
