### PR TITLE
fix(templates): never let MDX typos break the generated build

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -14,6 +14,8 @@ import {
   getFullSlug,
   isProcessEntrypoint,
 } from "./index.js";
+import { safeMatter } from "./lib/utils.js";
+import { docsTemplate } from "./templates/components/Docs.js";
 
 const execFileAsync = promisify(execFile);
 const selfPath = fileURLToPath(import.meta.url);
@@ -476,6 +478,108 @@ describe.skipIf(!fs.pathExistsSync(distEntry))("homepage RSS feed", () => {
         { maxBuffer: 20 * 1024 * 1024 },
       );
       expect(stdout).toContain("All matched files use Prettier code style!");
+    } finally {
+      await fs.remove(projectDir);
+    }
+  }, 120_000);
+});
+
+// The generated Docs component must never let a broken MDX body fail
+// `next build`: the body compiles through compileMDX inside a try/catch and
+// falls back to a danger Callout panel. These guards pin the template to that
+// shape so a refactor can't silently reintroduce the unguarded <MDXRemote>
+// path (which throws during static prerender and aborts the whole build).
+describe("Docs template MDX error guard", () => {
+  it("compiles the MDX body through compileMDX inside a try/catch", () => {
+    expect(docsTemplate).toContain(
+      'import { compileMDX } from "next-mdx-remote/rsc";',
+    );
+    expect(docsTemplate).toContain("catch (error)");
+    expect(docsTemplate).toContain('<Callout type="danger">');
+  });
+
+  it("does not render the unguarded MDXRemote component", () => {
+    expect(docsTemplate).not.toContain("<MDXRemote");
+  });
+});
+
+describe("safeMatter", () => {
+  it("parses valid frontmatter like gray-matter", () => {
+    const { data, content } = safeMatter('---\ntitle: "Hi"\n---\n\nBody.\n');
+    expect(data.title).toBe("Hi");
+    expect(content.trim()).toBe("Body.");
+  });
+
+  it("passes through files without frontmatter", () => {
+    const raw = "# Just a doc\n";
+    const { data, content } = safeMatter(raw);
+    expect(data).toEqual({});
+    expect(content).toBe(raw);
+  });
+
+  it("degrades broken YAML to empty frontmatter with the block stripped", () => {
+    const { data, content } = safeMatter(
+      '---\ntitle: "unclosed\n---\n\nBody.\n',
+      "badfm.mdx",
+    );
+    expect(data).toEqual({});
+    expect(content.trim()).toBe("Body.");
+  });
+});
+
+// A broken MDX body or frontmatter block must degrade per page, never abort
+// the CLI build: every page still gets emitted (the app-side guard renders
+// the error panel at prerender time) and invalid frontmatter is warned about.
+describe.skipIf(!fs.pathExistsSync(distEntry))("MDX error resilience", () => {
+  it("builds through broken MDX and broken frontmatter", async () => {
+    const projectDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "doccupine-broken-"),
+    );
+    try {
+      await fs.writeJson(path.join(projectDir, "doccupine.json"), {
+        watchDir: "docs",
+        outputDir: "out",
+        port: "3000",
+      });
+      await fs.outputFile(
+        path.join(projectDir, "docs", "index.mdx"),
+        '---\ntitle: "Home"\n---\n\n# Welcome\n',
+      );
+      await fs.outputFile(
+        path.join(projectDir, "docs", "broken.mdx"),
+        '---\ntitle: "Broken"\n---\n\nAn orphaned closing tag:\n\n</Card>\n',
+      );
+      await fs.outputFile(
+        path.join(projectDir, "docs", "badfm.mdx"),
+        '---\ntitle: "unclosed\n---\n\nStill readable body.\n',
+      );
+
+      const { stdout, stderr } = await execFileAsync(
+        process.execPath,
+        [distEntry, "build"],
+        { cwd: projectDir, maxBuffer: 20 * 1024 * 1024 },
+      );
+
+      const outDir = path.join(projectDir, "out");
+      const brokenPage = await fs.readFile(
+        path.join(outDir, "app", "(site)", "broken", "page.tsx"),
+        "utf8",
+      );
+      expect(brokenPage).toContain("</Card>");
+
+      const badfmPage = await fs.readFile(
+        path.join(outDir, "app", "(site)", "badfm", "page.tsx"),
+        "utf8",
+      );
+      expect(badfmPage).toContain("Still readable body.");
+      expect(`${stdout}${stderr}`).toContain("Invalid frontmatter");
+
+      const docsComponent = await fs.readFile(
+        path.join(outDir, "components", "Docs.tsx"),
+        "utf8",
+      );
+      expect(docsComponent).toContain("compileMDX");
+      expect(docsComponent).toContain('<Callout type="danger">');
     } finally {
       await fs.remove(projectDir);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ import fs from "fs-extra";
 import path from "path";
 import { fileURLToPath } from "url";
 
-import matter from "gray-matter";
 import chalk from "chalk";
 
 import {
@@ -28,6 +27,7 @@ import {
   escapeTemplateContent,
   toJsStringLiteral,
   resolvePackageManager,
+  safeMatter,
 } from "./lib/utils.js";
 import {
   generateMetadataBlock,
@@ -355,7 +355,7 @@ class MDXToNextJSGenerator {
     for (const file of files) {
       const fullPath = path.join(this.watchDir, file);
       const content = await fs.readFile(fullPath, "utf8");
-      const { data: frontmatter } = matter(content);
+      const { data: frontmatter } = safeMatter(content, file);
 
       if (frontmatter.section) {
         const label = frontmatter.section as string;
@@ -961,7 +961,7 @@ class MDXToNextJSGenerator {
   private async parseMDXFile(file: string): Promise<PageMeta> {
     const fullPath = path.join(this.watchDir, file);
     const content = await fs.readFile(fullPath, "utf8");
-    const { data: frontmatter } = matter(content);
+    const { data: frontmatter } = safeMatter(content, file);
 
     const { sectionSlug, pageSlug } = this.determineSectionForFile(
       file,
@@ -1050,7 +1050,10 @@ class MDXToNextJSGenerator {
   private async writePageForFile(filePath: string): Promise<void> {
     const fullPath = path.join(this.watchDir, filePath);
     const content = await fs.readFile(fullPath, "utf8");
-    const { data: frontmatter, content: mdxContent } = matter(content);
+    const { data: frontmatter, content: mdxContent } = safeMatter(
+      content,
+      filePath,
+    );
 
     const { sectionSlug, pageSlug } = this.determineSectionForFile(
       filePath,
@@ -1758,7 +1761,10 @@ export default function Page() {
       if (file === "index.mdx" || file === "./index.mdx") {
         const fullPath = path.join(this.watchDir, file);
         const content = await fs.readFile(fullPath, "utf8");
-        const { data: frontmatter, content: mdxContent } = matter(content);
+        const { data: frontmatter, content: mdxContent } = safeMatter(
+          content,
+          file,
+        );
 
         indexMDX = {
           content: mdxContent,
@@ -2158,7 +2164,7 @@ export default function Page() {
     }
     const fullPath = path.join(this.watchDir, page.path);
     const raw = await fs.readFile(fullPath, "utf8");
-    const { content: body } = matter(raw);
+    const { content: body } = safeMatter(raw, page.path);
     return { ...page, body };
   }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,6 +2,7 @@ import fs from "fs-extra";
 import path from "path";
 import { execSync } from "child_process";
 import chalk from "chalk";
+import matter from "gray-matter";
 
 export type PackageManagerName = "pnpm" | "npm";
 
@@ -122,6 +123,33 @@ export function escapeTemplateContent(content: string): string {
     .replace(/\\/g, "\\\\")
     .replace(/`/g, "\\`")
     .replace(/\$\{/g, "\\${");
+}
+
+/**
+ * gray-matter that never throws: malformed YAML frontmatter is reported as a
+ * warning and the file is treated as having no frontmatter, so one typo in a
+ * `---` block can't abort a whole build or site-wide aggregation pass. The
+ * broken block is stripped from the body best-effort; an unterminated block
+ * passes through as-is and the generated app's MDX error panel absorbs it.
+ */
+export function safeMatter(
+  raw: string,
+  label?: string,
+): { data: { [key: string]: any }; content: string } {
+  try {
+    const { data, content } = matter(raw);
+    return { data, content };
+  } catch (error) {
+    const where = label ? ` in ${label}` : "";
+    console.warn(
+      chalk.yellow(`⚠️  Invalid frontmatter${where}; ignoring it.`),
+      error instanceof Error ? error.message : error,
+    );
+    return {
+      data: {},
+      content: raw.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, ""),
+    };
+  }
 }
 
 /**

--- a/src/templates/app/api/rag/route.ts
+++ b/src/templates/app/api/rag/route.ts
@@ -50,6 +50,25 @@ Each context chunk includes a "URL:" line with the pre-computed page URL. Use it
 ## Greetings & Small Talk
 If the user sends a greeting or non-documentation question, respond briefly and ask how you can help with the documentation.\`;
 
+// Maps provider/stream failures to fixed visitor-safe messages. Raw provider
+// errors can include API-key fragments, org ids, and billing URLs, so only
+// these strings ever reach the client; the full error goes to the server log.
+function friendlyLLMError(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  if (/\\b401\\b|api.?key|authenticat|unauthorized/i.test(raw)) {
+    return "The assistant's model provider rejected its API key. If you are the site owner, check the server logs and your API key configuration.";
+  }
+  if (/\\b429\\b|quota|rate.?limit|billing/i.test(raw)) {
+    return "The assistant's model provider is rate limiting requests right now. Please try again in a moment.";
+  }
+  if (
+    /timed?.?out|ETIMEDOUT|ECONNRESET|ENOTFOUND|fetch failed|network/i.test(raw)
+  ) {
+    return "The assistant could not reach its model provider. Please try again.";
+  }
+  return "The assistant hit an unexpected error. Please try again.";
+}
+
 // LangChain + the MCP SDK require the Node.js runtime (not edge).
 export const runtime = "nodejs";
 // Safety net for the streaming function (Vercel-only; ignored elsewhere).
@@ -90,9 +109,15 @@ export async function POST(req: Request) {
   try {
     llmConfig = getLLMConfig();
   } catch (error: unknown) {
-    const message =
-      error instanceof Error ? error.message : "LLM configuration error";
-    return NextResponse.json({ error: message }, { status: 500 });
+    // Setup details (provider names, env var names) stay in the server log.
+    console.error("[doccupine] LLM configuration error:", error);
+    return NextResponse.json(
+      {
+        error:
+          "The AI assistant is not configured on this site. If you are the site owner, check the server logs.",
+      },
+      { status: 500 },
+    );
   }
 
   const encoder = new TextEncoder();
@@ -189,9 +214,9 @@ export async function POST(req: Request) {
 
         safeEnqueue(\`data: \${JSON.stringify({ type: "done" })}\\n\\n\`);
       } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : "Stream error";
+        console.error("[doccupine] RAG stream error:", error);
         safeEnqueue(
-          \`data: \${JSON.stringify({ type: "error", data: message })}\\n\\n\`,
+          \`data: \${JSON.stringify({ type: "error", data: friendlyLLMError(error) })}\\n\\n\`,
         );
       } finally {
         if (heartbeat) clearInterval(heartbeat);

--- a/src/templates/components/Chat.ts
+++ b/src/templates/components/Chat.ts
@@ -18,6 +18,7 @@ import { MDXRemote, MDXRemoteSerializeResult } from "next-mdx-remote";
 import { serialize } from "next-mdx-remote/serialize";
 import Link from "next/link";
 import { mq, Theme } from "@/app/theme";
+import { Callout } from "@/components/layout/Callout";
 import { useLockBodyScroll } from "@/components/LockBodyScroll";
 import { useMDXComponents as getMDXComponents } from "@/components/MDXComponents";
 import {
@@ -471,16 +472,9 @@ const StyledGlowSmallButton = styled(StyledSmallButton)<{
     \`}
 \`;
 
-const StyledError = styled.div<{ theme: Theme }>\`
-  overflow-x: auto;
-  \${thinScrollbar};
-  background: \${({ theme }) => theme.colors.error};
-  color: \${({ theme }) => theme.colors.surface};
-  padding: 10px;
-  border-radius: 8px;
+const StyledError = styled.div\`
   margin: 20px 0;
   width: 100%;
-  \${styledText};
 \`;
 
 const loadingDotAnimation = keyframes\`
@@ -889,7 +883,11 @@ function Chat() {
         )}
         {error && (
           <StyledError>
-            <strong>Error:</strong> {error}
+            <Callout type="danger">
+              <p>
+                <strong>Error:</strong> {error}
+              </p>
+            </Callout>
           </StyledError>
         )}
         <div ref={endRef} />
@@ -1078,69 +1076,70 @@ const ChtProvider = ({ children, isChatActive }: ChatContextProviderProps) => {
         buffer = parts.pop() ?? "";
 
         for (const line of parts) {
-          if (line.startsWith("data: ")) {
+          if (!line.startsWith("data: ")) continue;
+
+          // Guard only the parse: a malformed frame is skipped, while the
+          // server's error event below must throw past this loop to the
+          // outer catch so it renders in the chat's error callout instead
+          // of dying in a parse-error log.
+          let data;
+          try {
+            data = JSON.parse(line.slice(6));
+          } catch {
+            console.error("Failed to parse SSE data:", line);
+            continue;
+          }
+
+          if (data.type === "metadata") {
+            const allSources: Source[] = data.data?.sources ?? [];
+            const seen = new Set<string>();
+            sources = allSources.filter((s: Source) => {
+              if (s.score < 0.4 || seen.has(s.uri)) return false;
+              seen.add(s.uri);
+              return true;
+            });
+          } else if (data.type === "content") {
+            contentParts.push(data.data);
+            const streamedContent = contentParts.join("");
+
+            setAnswer((prev) => {
+              const newAnswers = [...prev];
+              newAnswers[streamingAnswerIndex] = {
+                text: streamedContent,
+                answer: true,
+                sources,
+              };
+              return newAnswers;
+            });
+          } else if (data.type === "error") {
+            throw new Error(data.data);
+          } else if (data.type === "done") {
+            const streamedContent = contentParts.join("");
+            let mdxSource: MDXRemoteSerializeResult | null = null;
             try {
-              const data = JSON.parse(line.slice(6));
-
-              if (data.type === "metadata") {
-                const allSources: Source[] = data.data?.sources ?? [];
-                const seen = new Set<string>();
-                sources = allSources.filter((s: Source) => {
-                  if (s.score < 0.4 || seen.has(s.uri)) return false;
-                  seen.add(s.uri);
-                  return true;
-                });
-              } else if (data.type === "content") {
-                contentParts.push(data.data);
-                const streamedContent = contentParts.join("");
-
-                setAnswer((prev) => {
-                  const newAnswers = [...prev];
-                  newAnswers[streamingAnswerIndex] = {
-                    text: streamedContent,
-                    answer: true,
-                    sources,
-                  };
-                  return newAnswers;
-                });
-              } else if (data.type === "error") {
-                throw new Error(data.data);
-              } else if (data.type === "done") {
-                const streamedContent = contentParts.join("");
-                let mdxSource: MDXRemoteSerializeResult | null = null;
-                try {
-                  mdxSource = await serialize(streamedContent, {
-                    parseFrontmatter: false,
-                    mdxOptions: {
-                      remarkPlugins: [remarkGfm],
-                      rehypePlugins: [rehypeHighlight],
-                      format: "md",
-                      development: false,
-                    },
-                  });
-                } catch (mdxError: unknown) {
-                  console.error("MDX serialization error:", mdxError);
-                }
-
-                setAnswer((prev) => {
-                  const newAnswers = [...prev];
-                  newAnswers[streamingAnswerIndex] = {
-                    text: streamedContent,
-                    answer: true,
-                    mdx: mdxSource || undefined,
-                    sources,
-                  };
-                  return newAnswers;
-                });
-              }
-            } catch (parseError) {
-              if (
-                parseError instanceof Error &&
-                parseError.message !== "Unknown error"
-              ) {
-                console.error("Failed to parse SSE data:", parseError);
-              }
+              mdxSource = await serialize(streamedContent, {
+                parseFrontmatter: false,
+                mdxOptions: {
+                  remarkPlugins: [remarkGfm],
+                  rehypePlugins: [rehypeHighlight],
+                  format: "md",
+                  development: false,
+                },
+              });
+            } catch (mdxError: unknown) {
+              console.error("MDX serialization error:", mdxError);
             }
+
+            setAnswer((prev) => {
+              const newAnswers = [...prev];
+              newAnswers[streamingAnswerIndex] = {
+                text: streamedContent,
+                answer: true,
+                mdx: mdxSource || undefined,
+                sources,
+              };
+              return newAnswers;
+            });
           }
         }
       }

--- a/src/templates/components/Docs.ts
+++ b/src/templates/components/Docs.ts
@@ -3,9 +3,9 @@ import { Flex } from "cherry-styled-components";
 import {
   DocsContainer,
   StyledMarkdownContainer,
-  StyledMissingComponent,
 } from "@/components/layout/DocsComponents";
-import { MDXRemote } from "next-mdx-remote/rsc";
+import { Callout } from "@/components/layout/Callout";
+import { compileMDX } from "next-mdx-remote/rsc";
 import remarkGfm from "remark-gfm";
 import { useMDXComponents } from "@/components/MDXComponents";
 import { createMermaidPre } from "@/components/MermaidPre";
@@ -82,10 +82,59 @@ function MissingComponent({
   children?: React.ReactNode;
 }) {
   return (
-    <StyledMissingComponent>
-      Missing component: &lt;{componentName} /&gt;
-    </StyledMissingComponent>
+    <Callout type="danger">
+      <p>Missing component: &lt;{componentName} /&gt;</p>
+    </Callout>
   );
+}
+
+interface MdxBodyProps {
+  source: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  components: Record<string, React.ComponentType<any>>;
+  sourcePath?: string;
+}
+
+// Compiles the MDX body inside a try/catch so an authoring mistake (an
+// orphaned closing tag, a stray {expression}) renders an inline error panel
+// instead of throwing during static prerender - a broken page must never
+// fail \`next build\` for the rest of the site.
+async function MdxBody({ source, components, sourcePath }: MdxBodyProps) {
+  try {
+    const { content } = await compileMDX({
+      source,
+      options: {
+        blockJS: false,
+        mdxOptions: {
+          remarkPlugins: [remarkGfm],
+          rehypePlugins: [rehypeCodeMeta],
+        },
+      },
+      components,
+    });
+    // JS expressions in the body only run when the compiled component
+    // renders, which would escape this try/catch and still fail the build.
+    // The compiled component is a plain sync function, so invoke it once
+    // here to surface those errors (a {placeholder} typo, for example).
+    if (typeof content.type === "function") {
+      await (content.type as React.FC<unknown>)(content.props);
+    }
+    return content;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const where = sourcePath ? \` in \${sourcePath}\` : "";
+    console.error(\`[doccupine] MDX error\${where}:\`, message);
+    return (
+      <Callout type="danger">
+        <p>
+          <strong>This page has an MDX error{where}.</strong> The rest of the
+          site still builds and renders. Fix the syntax below and save the file
+          to rebuild this page.
+        </p>
+        <pre>{message}</pre>
+      </Callout>
+    );
+  }
 }
 
 function Docs({ content, sourcePath, rssHref, children }: DocsProps) {
@@ -122,16 +171,10 @@ function Docs({ content, sourcePath, rssHref, children }: DocsProps) {
             <StyledMarkdownContainer>
               {children}
               {content && (
-                <MDXRemote
+                <MdxBody
                   source={content}
-                  options={{
-                    blockJS: false,
-                    mdxOptions: {
-                      remarkPlugins: [remarkGfm],
-                      rehypePlugins: [rehypeCodeMeta],
-                    },
-                  }}
                   components={allComponents}
+                  sourcePath={sourcePath}
                 />
               )}
             </StyledMarkdownContainer>

--- a/src/templates/components/layout/ApiPlayground.ts
+++ b/src/templates/components/layout/ApiPlayground.ts
@@ -13,6 +13,7 @@ import { Code, CodeTabs } from "@/components/layout/Code";
 import { Icon } from "@/components/layout/Icon";
 import { Accordion } from "@/components/layout/Accordion";
 import { Badge, httpMethodBadgeColor } from "@/components/layout/Badge";
+import { Callout } from "@/components/layout/Callout";
 import { CopyButton } from "@/components/layout/CopyButton";
 import { Spinner } from "@/components/Spinner";
 import { matchAllowlist, matchAllowlistIn } from "@/utils/playgroundAllowlist";
@@ -451,12 +452,6 @@ const StatusPill = styled.span<{ theme: Theme; $ok: boolean }>\`
 const Meta = styled.span\`
   \${({ theme }: { theme: Theme }) => styledSmall(theme)};
   color: \${({ theme }: { theme: Theme }) => theme.colors.gray};
-\`;
-
-const ErrorText = styled.p\`
-  margin: 0;
-  \${({ theme }: { theme: Theme }) => styledSmall(theme)};
-  color: \${({ theme }: { theme: Theme }) => theme.colors.error};
 \`;
 
 const Placeholder = styled.div\`
@@ -1004,7 +999,9 @@ export function ApiPlayground({
 
             {error ? (
               <Field>
-                <ErrorText>{error}</ErrorText>
+                <Callout type="danger">
+                  <p>{error}</p>
+                </Callout>
                 {corsRetry ? (
                   <Toggle type="button" onClick={retryViaProxy}>
                     Retry via proxy

--- a/src/templates/components/layout/DocsComponents.ts
+++ b/src/templates/components/layout/DocsComponents.ts
@@ -530,18 +530,6 @@ export const StyledMobileBurger = styled.span<Props>\`
     \`};
 \`;
 
-export const StyledMissingComponent = styled.div\`
-  background: \${({ theme }) => theme.colors.error};
-  border-radius: \${({ theme }) => theme.spacing.radius.lg};
-  padding: 20px;
-  font-size: \${({ theme }) => theme.fontSizes.small.lg};
-  color: \${({ theme }) => theme.colors.surface};
-  font-weight: 600;
-  display: flex;
-  gap: 10px;
-  align-items: center;
-\`;
-
 // Visually hidden but present for crawlers and agents: points at llms.txt and
 // the .md mirrors. Rendered as the first element of the site layout.
 const StyledLlmsDirective = styled.div\`

--- a/src/templates/package.ts
+++ b/src/templates/package.ts
@@ -26,7 +26,7 @@ export const packageJsonTemplate =
         minisearch: "^7.2.0",
         next: "16.2.12",
         "next-mdx-remote": "^6.0.0",
-        "posthog-js": "^1.407.4",
+        "posthog-js": "^1.407.8",
         "posthog-node": "^5.46.1",
         react: "19.2.8",
         "react-dom": "19.2.8",


### PR DESCRIPTION
## Summary

- A single broken MDX body or a malformed YAML frontmatter block anywhere in the docs tree could previously abort the entire generated site's `next build`. Bad content on one page must now degrade to that one page, not take down the whole site.
- `Docs.ts` replaces the unguarded `<MDXRemote>` with an async `MdxBody` component that awaits `compileMDX` inside a try/catch, probe-invokes the compiled component once to also catch expression errors (e.g. a stray `{placeholder}`), and falls back to a `<Callout type="danger">` panel showing the compiler message. Failures are logged as `[doccupine] MDX error in <file>`.
- `lib/utils.ts` adds a `safeMatter` wrapper around gray-matter so malformed frontmatter warns and degrades to an empty frontmatter object instead of throwing; `index.ts` routes all five frontmatter-parsing call sites through it.
- Separately, several ad-hoc styled error/status boxes across the generated templates (`Chat.ts`, `ApiPlayground.ts`, and the `MissingComponent` panel in `Docs.ts`) are replaced with the shared `Callout` component for consistent visual treatment, and the now-unused `StyledMissingComponent` is removed. While in `Chat.ts`'s SSE handling, a bug where a server-sent `error` event was silently swallowed by the JSON-parse catch block (instead of reaching the chat's error state) is also fixed.

## RAG route error sanitization

- The generated app's RAG chat route (`app/api/rag/route.ts`) previously forwarded raw provider/stream error messages straight to the client, which can leak API key fragments, provider identifiers, or billing URLs.
- Adds `friendlyLLMError()`, mapping any caught error to one of a fixed set of visitor-safe messages (auth/API key, rate limit/billing, network/timeout, or a generic fallback) instead of surfacing `error.message` directly. Full errors are still logged server-side (`[doccupine] LLM configuration error`, `[doccupine] RAG stream error`).

## Dependency bump

- Bumps the generated app's `posthog-js` pin from `^1.407.4` to `^1.407.8`.

## Failure modes closed

- MDX syntax errors (e.g. an orphaned closing tag) in a page body.
- Stray JS expressions in MDX content (e.g. an unresolved `{placeholder}`) that only throw when the compiled component actually renders.
- Malformed YAML frontmatter blocks that previously threw out of gray-matter and aborted the whole CLI build/watch pass.
- Raw provider/stream error details leaking to visitors through the RAG chat API.

## Verification

- `pnpm build` clean, full vitest suite passing (including the generated-app prettier-clean suite and a new integration test that builds a site with a broken MDX body and broken frontmatter and asserts the CLI build still succeeds).
- A real generated app's `next build` succeeds with broken pages rendering the error callout while the rest of the site's static pages build normally.

## Test plan

- [x] `pnpm build && pnpm test`
- [x] `node dist/index.js build` against a docs tree containing a broken MDX page and confirm the rest of the site still builds
- [x] Trigger an RAG/LLM error (e.g. bad API key) and confirm the client only sees the sanitized message while the full error appears in server logs